### PR TITLE
Updates

### DIFF
--- a/hredis.go
+++ b/hredis.go
@@ -27,6 +27,9 @@ func RedissURL(s string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if p == "" {
+		return "", errors.New("missing port")
+	}
 	port, err := strconv.Atoi(p)
 	if err != nil {
 		return "", err

--- a/hredis.go
+++ b/hredis.go
@@ -1,0 +1,39 @@
+package hredis
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"strconv"
+)
+
+// RedissURL (rediss://) from an insecure redis:// url. Meant to be used as
+// RedissURL(os.Getenv("REDIS_URL")). This eliminates the need for the
+// heroku-redis-buildpack (https://github.com/heroku/heroku-buildpack-redis) for
+// premium-* plans. Does not work with hobby-dev plans.
+func RedissURL(s string) (string, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "redis": // NOOP
+	case "rediss":
+		return s, nil
+	default:
+		return "", errors.New("invalid scheme " + u.Scheme)
+	}
+	h, p, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return "", err
+	}
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		return "", err
+	}
+	port++
+	u.Scheme = "rediss"
+
+	u.Host = net.JoinHostPort(h, strconv.Itoa(port))
+	return u.String(), nil
+}

--- a/hredis/redigo/redigo.go
+++ b/hredis/redigo/redigo.go
@@ -1,4 +1,4 @@
-package redis
+package redigo
 
 import (
 	"time"
@@ -20,7 +20,7 @@ func WaitForAvailability(url string, d time.Duration, f WaitFunc) (bool, error) 
 			c, err := redis.DialURL(url)
 			if err == nil {
 				c.Close()
-				conn <- struct{}{}
+				close(conn)
 				return
 			}
 			if f != nil {


### PR DESCRIPTION
* Make this explicitly about redigo.
* Add support for changing the redis:// url to rediss://. This will be
usable once https://github.com/garyburd/redigo/pull/208 lands.
* Remove our own url parser as current versions of redigo already supply
one.