### PR TITLE
counters: value reset every submission

### DIFF
--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -238,7 +238,7 @@ func (p *Provider) report(u *url.URL, interval time.Duration) error {
 	period := interval.Seconds()
 
 	for _, c := range p.counters {
-		v := c.Value()
+		v := c.ValueReset()
 		r.Gauges = append(r.Gauges, gauge{Name: c.Name, Period: period, Count: 1, Sum: v, Min: v, Max: v, SumSq: v * v})
 	}
 	for _, g := range p.gauges {


### PR DESCRIPTION
After trying out the current approach, it appears it's more work
since it will require you to derive every single chart metric.

Doing a reset on the counter simplifies a lot of this.