### PR TITLE
ssa enabled: all metrics are submitted with SSA

### DIFF
--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -230,9 +230,19 @@ type gauge struct {
 	Min    float64 `json:"min"`
 	Max    float64 `json:"max"`
 	SumSq  float64 `json:"sum_squares"`
+}
 
-	// Attributes are used to enable SSA for gauges.
-	Attributes map[string]interface{} `json:"attributes,omitempty"`
+// attributes are top level things which you can use to affect newly created
+// metrics.
+type attributes struct {
+	Color             string  `json:"color,omitempty"`
+	DisplayMin        float64 `json:"display_min,omitempty"`
+	DisplayMax        float64 `json:"display_max,omitempty"`
+	DisplayUnitsShort string  `json:"display_units_short,omitempty"`
+	DisplayUnitsLong  string  `json:"display_units_long,omitempty"`
+	DisplayStacked    bool    `json:"display_stacked,omitempty"`
+	SummarizeFunction string  `json:"summarize_function,omitempty"`
+	Aggregate         bool    `json:"aggregate,omitempty"`
 }
 
 // report the metrics to the url, every interval
@@ -247,18 +257,18 @@ func (p *Provider) report(u *url.URL, interval time.Duration) error {
 	var buf bytes.Buffer
 	e := json.NewEncoder(&buf)
 	r := struct {
-		Source      string                 `json:"source,omitempty"`
-		MeasureTime int64                  `json:"measure_time"`
-		Counters    []counter              `json:"counters"`
-		Gauges      []gauge                `json:"gauges"`
-		Attributes  map[string]interface{} `json:"attributes,omitempty"`
+		Source      string      `json:"source,omitempty"`
+		MeasureTime int64       `json:"measure_time"`
+		Counters    []counter   `json:"counters"`
+		Gauges      []gauge     `json:"gauges"`
+		Attributes  *attributes `json:"attributes,omitempty"`
 	}{}
 
 	r.Source = p.source
 	ivSec := int64(interval / time.Second)
 	r.MeasureTime = (time.Now().Unix() / ivSec) * ivSec
 	if p.ssa {
-		r.Attributes = map[string]interface{}{"aggregate": true}
+		r.Attributes = &attributes{Aggregate: true}
 	}
 	period := interval.Seconds()
 

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -235,14 +235,7 @@ type gauge struct {
 // attributes are top level things which you can use to affect newly created
 // metrics.
 type attributes struct {
-	Color             string  `json:"color,omitempty"`
-	DisplayMin        float64 `json:"display_min,omitempty"`
-	DisplayMax        float64 `json:"display_max,omitempty"`
-	DisplayUnitsShort string  `json:"display_units_short,omitempty"`
-	DisplayUnitsLong  string  `json:"display_units_long,omitempty"`
-	DisplayStacked    bool    `json:"display_stacked,omitempty"`
-	SummarizeFunction string  `json:"summarize_function,omitempty"`
-	Aggregate         bool    `json:"aggregate,omitempty"`
+	Aggregate bool `json:"aggregate,omitempty"`
 }
 
 // report the metrics to the url, every interval


### PR DESCRIPTION
## Reasons for doing this

Certain projects use a single source for many dynos. This posting style requires SSA enabled for all metrics. To avoid having to manually enable SSA for new metrics created, it's easier to make this automatic.

## Description of changes

- add `WithSSA` option
- submits a payload like the following if enabled:

```
curl -u $LIBRATO_USERNAME:$LIBRATO_TOKEN -H "Content-Type: application/json" -d '{
  "source": "xyz.foobarbaz",
  "gauges": [{
    "name": "xyz.foobarbaz.gauge1",
    "period": 60,
    "min": 1,
    "max": 1,
    "sum": 1,
    "sum_squares": 1,
    "count": 1
  }], "attributes": { "aggregate": true }
}' -X POST 'https://metrics-api.librato.com/v1/metrics' -i
```