### PR TITLE
hmetrics: Simplify error reporting and other cleanups

### DIFF
--- a/hmetrics/example/advanced/main.go
+++ b/hmetrics/example/advanced/main.go
@@ -17,8 +17,11 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hml := log.New(os.Stderr, "heroku metrics", 0)
-	if err := hmetrics.Report(ctx, hml); err != nil {
+	eh := func(err error) error {
+		log.Println("Error reporting metrics to heroku:", err)
+		return nil
+	}
+	if err := hmetrics.Report(ctx, eh); err != nil {
 		if f, ok := err.(fataler); ok {
 			if f.Fatal() {
 				log.Fatal(err)

--- a/hmetrics/init.go
+++ b/hmetrics/init.go
@@ -16,10 +16,6 @@ const (
 	metricWaitTime = 20 * time.Second
 )
 
-type printfer interface {
-	Printf(s string, v ...interface{})
-}
-
 type AlreadyStarted struct{}
 
 func (as AlreadyStarted) Error() string {
@@ -45,7 +41,11 @@ var (
 	started bool
 )
 
-func Report(ctx context.Context, pfer printfer) error {
+// ErrHandler receives any errors encountered during collection or reporting of metrics to Heroku. Processing of metrics
+// continues if the ErrHandler returns nil, but aborts if the ErrHandler itself returns an error.
+type ErrHandler func(err error) error
+
+func Report(ctx context.Context, ef ErrHandler) error {
 	mu.Lock()
 	defer mu.Unlock()
 	if started {
@@ -55,12 +55,22 @@ func Report(ctx context.Context, pfer printfer) error {
 	if endpoint == "" {
 		return HerokuMetricsURLUnset{}
 	}
-	go report(ctx, endpoint, pfer)
+	if ef == nil {
+		ef = func(_ error) error { return nil }
+	}
+	go report(ctx, endpoint, ef)
 	started = true
 	return nil
 }
 
-func report(ctx context.Context, endpoint string, pfer printfer) {
+// The only thing that should come after and exit() is a return
+func exit() {
+	mu.Lock()
+	defer mu.Unlock()
+	started = false
+}
+
+func report(ctx context.Context, endpoint string, ef ErrHandler) {
 	t := time.NewTicker(metricWaitTime)
 	defer t.Stop()
 
@@ -68,18 +78,22 @@ func report(ctx context.Context, endpoint string, pfer printfer) {
 		select {
 		case <-t.C:
 		case <-ctx.Done():
-			mu.Lock()
-			defer mu.Unlock()
-			started = false
+			exit()
 			return
 		}
 
-		if err := gatherMetrics(); err != nil && pfer != nil {
-			pfer.Printf("error encoding metrics: %v", err)
+		if err := gatherMetrics(); err != nil {
+			if err := ef(err); err != nil {
+				exit()
+				return
+			}
 			continue
 		}
-		if err := submitPayload(ctx, endpoint); err != nil && pfer != nil {
-			pfer.Printf("error submitting metrics: %v", err)
+		if err := submitPayload(ctx, endpoint); err != nil {
+			if err := ef(err); err != nil {
+				exit()
+				return
+			}
 			continue
 		}
 	}
@@ -91,8 +105,8 @@ var (
 )
 
 func gatherMetrics() error {
-	stats := &runtime.MemStats{}
-	runtime.ReadMemStats(stats)
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
 
 	// cribbed from https://github.com/codahale/metrics/blob/master/runtime/memstats.go
 


### PR DESCRIPTION
This simplifies the error reporting with an error handler letting
the user determine how to best handle the error.

Returning an error from the error handler abort metrics reporting
as well, giving the user an escape valve.

Additionally make the sharing of stats with ReadMemStats explicit.