### PR TITLE
A bunch of cleanups; see comments

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2018, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be
+used to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/hmetrics/doc.go
+++ b/hmetrics/doc.go
@@ -1,5 +1,18 @@
-/*
-package hmetrics is a self-contained client for heroku Go runtime metrics.
-*/
+/* Copyright (c) 2018 Salesforce
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
 
+/*
+Package hmetrics is a self-contained client for Heroku Go runtime metrics.
+
+Typical usage is through the `github.com/heroku/x/hmetrics/onload` package
+imported like so:
+
+  import _ "github.com/heroku/x/hmetrics/onload"
+
+You can find more information about Heroku Go runtime metrics here:
+https://devcenter.heroku.com/articles/language-runtime-metrics-go
+*/
 package hmetrics

--- a/hmetrics/example/advanced/main.go
+++ b/hmetrics/example/advanced/main.go
@@ -21,14 +21,21 @@ func main() {
 		log.Println("Error reporting metrics to heroku:", err)
 		return nil
 	}
-	if err := hmetrics.Report(ctx, eh); err != nil {
-		if f, ok := err.(fataler); ok {
-			if f.Fatal() {
-				log.Fatal(err)
-			}
-			log.Println(err)
-		}
-	}
 
-	http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+	go func() {
+		for {
+			if err := hmetrics.Report(ctx, eh); err != nil {
+				if f, ok := err.(fataler); ok && f.Fatal() {
+					log.Fatal(err)
+				}
+				log.Println(err)
+			}
+		}
+	}()
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	http.ListenAndServe(":"+port, nil)
 }

--- a/hmetrics/example/basic/main.go
+++ b/hmetrics/example/basic/main.go
@@ -10,7 +10,11 @@ import (
 
 func main() {
 	// Don't care about canceling or errors
-	hmetrics.Report(context.Background(), nil)
+	go func() { hmetrics.Report(context.Background(), nil) }()
 
-	http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	http.ListenAndServe(":"+port, nil)
 }

--- a/hmetrics/example/basic/main.go
+++ b/hmetrics/example/basic/main.go
@@ -1,3 +1,8 @@
+/* Copyright (c) 2018 Salesforce
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
 package main
 
 import (
@@ -10,7 +15,7 @@ import (
 
 func main() {
 	// Don't care about canceling or errors
-	go func() { hmetrics.Report(context.Background(), nil) }()
+	go hmetrics.Report(context.Background(), hmetrics.DefaultEndpoint, nil)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/hmetrics/example/onload/main.go
+++ b/hmetrics/example/onload/main.go
@@ -8,5 +8,9 @@ import (
 )
 
 func main() {
-	http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	http.ListenAndServe(":"+port, nil)
 }

--- a/hmetrics/examples_test.go
+++ b/hmetrics/examples_test.go
@@ -3,7 +3,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
-package main
+package hmetrics_test
 
 import (
 	"context"
@@ -14,7 +14,28 @@ import (
 	"github.com/heroku/x/hmetrics"
 )
 
-func main() {
+func ExampleReport_basic() {
+	// Don't care about canceling or errors
+	go hmetrics.Report(context.Background(), hmetrics.DefaultEndpoint, nil)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	http.ListenAndServe(":"+port, nil)
+}
+
+func ExampleReport_logging() {
+	go func() {
+		if err := hmetrics.Report(context.Background(), hmetrics.DefaultEndpoint, func(err error) error {
+			log.Println("Error reporting metrics to heroku:", err)
+			return nil
+		}); err != nil {
+			log.Fatal("Error starting hmetrics reporting:", err)
+		}
+	}()
+}
+func ExampleReport_advanced() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/hmetrics/hmetrics_test.go
+++ b/hmetrics/hmetrics_test.go
@@ -3,19 +3,13 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
-package main
+package hmetrics
 
-import (
-	"net/http"
-	"os"
+import "testing"
 
-	_ "github.com/heroku/x/hmetrics/onload"
-)
-
-func main() {
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
+func TestStartable_EmptyEndpoint(t *testing.T) {
+	err := startable("")
+	if err == nil {
+		t.Errorf("Expected an error, but got nil instead")
 	}
-	http.ListenAndServe(":"+port, nil)
 }

--- a/hmetrics/onload/README.md
+++ b/hmetrics/onload/README.md
@@ -1,7 +1,0 @@
-runtime-metrics
-===============
-
-This will only be useful if you are inside the runtime metrics private beta.
-
-This package, once loaded, will implicitly dump a subset of runtime performace
-metrics to the URL denoted by `HEROKU_METRICS_URL`

--- a/hmetrics/onload/init.go
+++ b/hmetrics/onload/init.go
@@ -1,8 +1,15 @@
-/*
-package onload automatically starts up the hmetrics reporting.
+/* Copyright (c) 2018 Salesforce
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
 
-Use this package when you don't care about shutting down them metrics reporting or being notified of any reporting
-errors.
+/*
+Package onload automatically starts hmetrics reporting, ignoring errors and
+retrying reporting, backing off in 10 second increments.
+
+Use this package when you don't care about stopping reporting, specifying the
+endpoint, or being notified of any reporting errors.
 
 usage:
 
@@ -10,18 +17,33 @@ import (
 	_ "github.com/heroku/x/hmetrics/onload"
 )
 
-*/
+See github.com/heroku/x/hmetrics documentation for more info about Heroku Go
+metrics and advanced usage.
 
+*/
 package onload
 
 import (
 	"context"
+	"time"
 
 	"github.com/heroku/x/hmetrics"
 )
 
+const (
+	interval = 10
+)
+
 func init() {
 	go func() {
-		hmetrics.Report(context.Background(), nil)
+		var backoff int64
+		for backoff = 1; ; backoff++ {
+			start := time.Now()
+			hmetrics.Report(context.Background(), hmetrics.DefaultEndpoint, nil)
+			if time.Since(start) > 5*time.Minute {
+				backoff = 1
+			}
+			time.Sleep(time.Duration(backoff*interval) * time.Second)
+		}
 	}()
 }

--- a/hmetrics/onload/init.go
+++ b/hmetrics/onload/init.go
@@ -12,7 +12,7 @@ import (
 
 */
 
-package onloads
+package onload
 
 import (
 	"context"
@@ -21,5 +21,7 @@ import (
 )
 
 func init() {
-	hmetrics.Report(context.Background(), nil)
+	go func() {
+		hmetrics.Report(context.Background(), nil)
+	}()
 }


### PR DESCRIPTION
Document everything more, including usage of all exported bits.

Reduce the use of global variables down to the started flag and it's mutex.

Report is now synchronous, pushing that off to the caller if they directly use
Report. onload is unaffected. Cleaned up examples to reflect this.

Fixed the package name declaration in onload (was onloads by accident).

Renamed a few functions and variables for clarity.