### PR TITLE
hmetrics/onload: spew metrics errors when HMETRICS_VERBOSE is set truthy

### DIFF
--- a/hmetrics/onload/init.go
+++ b/hmetrics/onload/init.go
@@ -11,10 +11,10 @@ retrying reporting, backing off in 10 second increments.
 Use this package when you don't care about stopping reporting, specifying the
 endpoint, or being notified of any reporting errors.
 
-This package additionally will report all metrics reporting errors using package
-log to the standard error file descriptor if you set the environment variable
-`HMETRICS_VERBOSE` to `1` or another true-like value as defined by
-https://godoc.org/strconv#ParseBool.
+This package will log all reporting errors via the stdlib log package if the
+environment variable HMETRICS_VERBOSE is set to "1", or any other true-like
+value as defined by strconv#ParseBool (see $ godoc strconv for more
+information).
 
 usage:
 
@@ -43,29 +43,27 @@ const (
 )
 
 func init() {
+	var logger hmetrics.ErrHandler = func(_ error) error { return nil }
+
+	val := os.Getenv("HMETRICS_VERBOSE")
+	should, err := strconv.ParseBool(val)
+	if err == nil && should {
+		logger = func(err error) error {
+			log.Printf("[hmetrics] error: %v", err)
+			return nil
+		}
+	}
+
 	go func() {
 		var backoff int64
 		for backoff = 1; ; backoff++ {
 			start := time.Now()
 
-			var logger hmetrics.ErrHandler
-
-			val := os.Getenv("HMETRICS_VERBOSE")
-			should, err := strconv.ParseBool(val)
-			if err == nil && should {
-				logger = func(err error) error {
-					log.Printf("[hmetrics] error: %v", err)
-					return nil
-				}
-			}
-
 			err = hmetrics.Report(context.Background(), hmetrics.DefaultEndpoint, logger)
 			if time.Since(start) > 5*time.Minute {
 				backoff = 1
 			}
-			if logger != nil {
-				logger(err)
-			}
+			_ = logger(err)
 
 			time.Sleep(time.Duration(backoff*interval) * time.Second)
 		}

--- a/hmetrics/onload/init.go
+++ b/hmetrics/onload/init.go
@@ -63,7 +63,7 @@ func init() {
 			if time.Since(start) > 5*time.Minute {
 				backoff = 1
 			}
-			_ = logger(err)
+			logger(err)
 
 			time.Sleep(time.Duration(backoff*interval) * time.Second)
 		}

--- a/hmetrics/onload/init.go
+++ b/hmetrics/onload/init.go
@@ -11,20 +11,28 @@ retrying reporting, backing off in 10 second increments.
 Use this package when you don't care about stopping reporting, specifying the
 endpoint, or being notified of any reporting errors.
 
+This package additionally will report all metrics reporting errors using package
+log to the standard error file descriptor if you set the environment variable
+`HMETRICS_VERBOSE` to `1` or another true-like value as defined by
+https://godoc.org/strconv#ParseBool.
+
 usage:
 
   import (
 	_ "github.com/heroku/x/hmetrics/onload"
   )
 
-See github.com/heroku/x/hmetrics documentation for more info about Heroku Go
-metrics and advanced usage.
+See the package documentation at https://godoc.org/github.com/heroku/x/hmetrics
+for more info about Heroku Go metrics and advanced usage.
 
 */
 package onload
 
 import (
 	"context"
+	"log"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/heroku/x/hmetrics"
@@ -39,10 +47,26 @@ func init() {
 		var backoff int64
 		for backoff = 1; ; backoff++ {
 			start := time.Now()
-			hmetrics.Report(context.Background(), hmetrics.DefaultEndpoint, nil)
+
+			var logger hmetrics.ErrHandler
+
+			val := os.Getenv("HMETRICS_VERBOSE")
+			should, err := strconv.ParseBool(val)
+			if err == nil && should {
+				logger = func(err error) error {
+					log.Printf("[hmetrics] error: %v", err)
+					return nil
+				}
+			}
+
+			err = hmetrics.Report(context.Background(), hmetrics.DefaultEndpoint, logger)
 			if time.Since(start) > 5*time.Minute {
 				backoff = 1
 			}
+			if logger != nil {
+				logger(err)
+			}
+
 			time.Sleep(time.Duration(backoff*interval) * time.Second)
 		}
 	}()


### PR DESCRIPTION
Currently package `hmetrics` in the `onload` configuration ignores all errors instead of logging them. This can make debugging of metrics collection errors very difficult and time-consuming. This patch offers a middle path between every error always being logged by default and no errors being logged. When the user sets `HMETRICS_VERBOSE=1` in the environment, all errors will be logged when they happen.

## Stories this patch fulfills
```
As a user of package hmetrics in customer code
In order to better debug metrics collection errors
Given the user set HMETRICS_VERBOSE to 1
When there is a reporting error
Then the reporting error is printed to standard error
```
```
As a user of package hmetrics in customer code
In order to better debug metrics collection errors
Given the user set HMETRICS_VERBOSE to 0
When there is a reporting error
Then the reporting error is not printed to standard error
```