### PR TITLE
tags: phase 1 support

### DIFF
--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -242,16 +242,6 @@ func keyName(name string, labelValues ...string) string {
 
 // metricName returns the name we'll use for the metric depending on
 // whether we're using tags or not.
-//
-// GIVEN
-//   name = requests
-//   tags = { region = us, app = myapp }
-//
-// TAGS ENABLED:
-//   requests
-//
-// TAGS DISABLED:
-//   requests.region:us.app:myapp
 func (p *Provider) metricName(name string, labelValues ...string) string {
 	if p.tagsEnabled {
 		return name

--- a/go-kit/metrics/provider/librato/report.go
+++ b/go-kit/metrics/provider/librato/report.go
@@ -90,11 +90,12 @@ func (p *Provider) sample(period float64) []gauge {
 		} else {
 			v = c.Value()
 		}
-		gauges = append(gauges, gauge{Name: c.Name, Period: period, Count: 1, Sum: v, Min: v, Max: v, SumSq: v * v})
+		gauges = append(gauges, gauge{Name: c.metricName(), Period: period, Count: 1, Sum: v, Min: v, Max: v, SumSq: v * v})
 	}
 	for _, g := range p.gauges {
 		v := g.Value()
-		gauges = append(gauges, gauge{Name: g.Name, Period: period, Count: 1, Sum: v, Min: v, Max: v, SumSq: v * v})
+
+		gauges = append(gauges, gauge{Name: g.metricName(), Period: period, Count: 1, Sum: v, Min: v, Max: v, SumSq: v * v})
 	}
 	for _, h := range p.histograms {
 		gauges = append(gauges, h.measures(period)...)


### PR DESCRIPTION
## Context

As part of doing our HTTP availability work in @heroku/runtime-tbd we've begun to explore the possibility of using a librato account with tags.

In order to start supporting tags, we'll want to change the semantics of `With(...)` to first of all:

1. Work
2. Register itself to something

## Phase 1

Phase 1 is to just splat out the label values into the name using a convention, e.g. given:

```
prefix: heroku
name: http_request
tags: { region: us, app: myapp, space: myspace }
```

It computes to:

```
heroku.http_request.region:us.app:myapp.space:myspace
```

## Next steps

The next step is to separate out the reporter into 2 concrete interfaces with the same interface. A v1 and a v2 which will be switched to v2 automatically when you do `WithTags`.

The interface is drastically different that it seems to warrant this, specifically:

1. It seems that it wants to post to `/v1/measurements` instead for tags
2. `measure_time` is no longer a global thing in the payload, but per measurement
3. `sum_squares` is no longer a thing, but seems to now require `stddev`

There's a bunch more details which will be fleshed out in a follow up PR.

## Unknown / out of scope for now

`HLLCounter` seems to be significantly different in terms of implementation so I've left it out for now.