### PR TITLE
BUGFIX: fix over prefixing

### DIFF
--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -264,7 +264,7 @@ func (p *Provider) metricName(name string, labelValues ...string) string {
 // report use the WithResetCounters option function, otherwise the counter's
 // value will increase until restart.
 func (p *Provider) NewCounter(name string) kmetrics.Counter {
-	return p.newCounter(name)
+	return p.newCounter(prefixName(p.prefix, name))
 }
 
 func (p *Provider) newCounter(name string, labelValues ...string) kmetrics.Counter {
@@ -273,7 +273,7 @@ func (p *Provider) newCounter(name string, labelValues ...string) kmetrics.Count
 
 	k := keyName(name, labelValues...)
 	if _, ok := p.counters[k]; !ok {
-		gc := generic.NewCounter(prefixName(p.prefix, name))
+		gc := generic.NewCounter(name)
 
 		if len(labelValues) > 0 {
 			gc = gc.With(labelValues...).(*generic.Counter)
@@ -290,7 +290,7 @@ func (p *Provider) newCounter(name string, labelValues ...string) kmetrics.Count
 
 // NewGauge that will be reported by the provider.
 func (p *Provider) NewGauge(name string) kmetrics.Gauge {
-	return p.newGauge(name)
+	return p.newGauge(prefixName(p.prefix, name))
 }
 
 func (p *Provider) newGauge(name string, labelValues ...string) kmetrics.Gauge {
@@ -299,7 +299,7 @@ func (p *Provider) newGauge(name string, labelValues ...string) kmetrics.Gauge {
 
 	k := keyName(name, labelValues...)
 	if _, ok := p.gauges[k]; !ok {
-		gg := generic.NewGauge(prefixName(p.prefix, name))
+		gg := generic.NewGauge(name)
 
 		if len(labelValues) > 0 {
 			gg = gg.With(labelValues...).(*generic.Gauge)
@@ -316,7 +316,7 @@ func (p *Provider) newGauge(name string, labelValues ...string) kmetrics.Gauge {
 
 // NewHistogram that will be reported by the provider.
 func (p *Provider) NewHistogram(name string, buckets int) kmetrics.Histogram {
-	return p.newHistogram(name, buckets, p.percentilePrefix)
+	return p.newHistogram(prefixName(p.prefix, name), buckets, p.percentilePrefix)
 }
 
 func (p *Provider) newHistogram(name string, buckets int, percentilePrefix string, labelValues ...string) kmetrics.Histogram {
@@ -327,7 +327,7 @@ func (p *Provider) newHistogram(name string, buckets int, percentilePrefix strin
 	if _, ok := p.histograms[k]; !ok {
 		h := &Histogram{
 			p:                p,
-			name:             prefixName(p.prefix, name),
+			name:             name,
 			buckets:          buckets,
 			percentilePrefix: percentilePrefix,
 			labelValues:      labelValues,

--- a/go-kit/metrics/provider/librato/librato_test.go
+++ b/go-kit/metrics/provider/librato/librato_test.go
@@ -846,3 +846,174 @@ func TestGaugeLabelValues(t *testing.T) {
 		t.Fatalf("want name %q, got %q", "test.gauge.region:us.space:myspace", g3.metricName())
 	}
 }
+
+func TestCounterNaming(t *testing.T) {
+	tests := []struct {
+		name     string
+		p        *Provider
+		fn       func(p *Provider) kmetrics.Counter
+		wantName string
+	}{
+		{
+			name:     "no prefix, no label values",
+			p:        &Provider{counters: make(map[string]*Counter)},
+			fn:       func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter") },
+			wantName: "my-counter",
+		},
+
+		{
+			name:     "with prefix, no label values",
+			p:        &Provider{prefix: "my-prefix", counters: make(map[string]*Counter)},
+			fn:       func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter") },
+			wantName: "my-prefix.my-counter",
+		},
+
+		{
+			name:     "no prefix, with label values",
+			p:        &Provider{counters: make(map[string]*Counter)},
+			fn:       func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
+			wantName: "my-counter",
+		},
+
+		{
+			name:     "no prefix, with label values, tags enabled",
+			p:        &Provider{counters: make(map[string]*Counter), tagsEnabled: true},
+			fn:       func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
+			wantName: "my-counter",
+		},
+
+		{
+			name:     "with prefix, with label values, tags enabled",
+			p:        &Provider{prefix: "my-prefix", counters: make(map[string]*Counter), tagsEnabled: true},
+			fn:       func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
+			wantName: "my-prefix.my-counter",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			counter := test.fn(test.p)
+			if got := counter.(*Counter).Counter.Name; test.wantName != got {
+				t.Fatalf("want name: %q, got %q", test.wantName, got)
+			}
+		})
+	}
+}
+
+func TestGaugeNaming(t *testing.T) {
+	tests := []struct {
+		name     string
+		p        *Provider
+		fn       func(p *Provider) kmetrics.Gauge
+		wantName string
+	}{
+		{
+			name:     "no prefix, no label values",
+			p:        &Provider{gauges: make(map[string]*Gauge)},
+			fn:       func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge") },
+			wantName: "my-gauge",
+		},
+
+		{
+			name:     "with prefix, no label values",
+			p:        &Provider{prefix: "my-prefix", gauges: make(map[string]*Gauge)},
+			fn:       func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge") },
+			wantName: "my-prefix.my-gauge",
+		},
+
+		{
+			name:     "no prefix, with label values",
+			p:        &Provider{gauges: make(map[string]*Gauge)},
+			fn:       func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
+			wantName: "my-gauge",
+		},
+
+		{
+			name:     "no prefix, with label values, tags enabled",
+			p:        &Provider{gauges: make(map[string]*Gauge), tagsEnabled: true},
+			fn:       func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
+			wantName: "my-gauge",
+		},
+
+		{
+			name:     "with prefix, with label values, tags enabled",
+			p:        &Provider{prefix: "my-prefix", gauges: make(map[string]*Gauge), tagsEnabled: true},
+			fn:       func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
+			wantName: "my-prefix.my-gauge",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			gauge := test.fn(test.p)
+			if got := gauge.(*Gauge).Gauge.Name; test.wantName != got {
+				t.Fatalf("want name: %q, got %q", test.wantName, got)
+			}
+		})
+	}
+}
+
+func TestHistogramNaming(t *testing.T) {
+	tests := []struct {
+		name     string
+		p        *Provider
+		fn       func(p *Provider) kmetrics.Histogram
+		wantName string
+	}{
+		{
+			name:     "no prefix, no label values",
+			p:        &Provider{histograms: make(map[string]*Histogram)},
+			fn:       func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50) },
+			wantName: "my-histogram",
+		},
+
+		{
+			name:     "with prefix, no label values",
+			p:        &Provider{prefix: "my-prefix", histograms: make(map[string]*Histogram)},
+			fn:       func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50) },
+			wantName: "my-prefix.my-histogram",
+		},
+
+		{
+			name:     "no prefix, with label values",
+			p:        &Provider{histograms: make(map[string]*Histogram)},
+			fn:       func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
+			wantName: "my-histogram",
+		},
+
+		{
+			name:     "no prefix, with label values, tags enabled",
+			p:        &Provider{histograms: make(map[string]*Histogram), tagsEnabled: true},
+			fn:       func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
+			wantName: "my-histogram",
+		},
+
+		{
+			name:     "with prefix, with label values, tags enabled",
+			p:        &Provider{prefix: "my-prefix", histograms: make(map[string]*Histogram), tagsEnabled: true},
+			fn:       func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
+			wantName: "my-prefix.my-histogram",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			histogram := test.fn(test.p)
+			if got := histogram.(*Histogram).name; test.wantName != got {
+				t.Fatalf("want name: %q, got %q", test.wantName, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

We previously added tags. That stab mistakenly applied the prefix over and over.

## Fix

In addition to the fix, added some table tests to ensure this regression won't happen.