### PR TITLE
go-kit/metrics/provider/librato: combine batcher types, add default tags

### DIFF
--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -270,7 +270,7 @@ func (p *Provider) newCounter(name string, labelValues ...string) kmetrics.Count
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	labelValues = append(labelValues, p.defaultTags...)
+	labelValues = p.applyDefaultTags(labelValues...)
 
 	k := keyName(name, labelValues...)
 	if _, ok := p.counters[k]; !ok {
@@ -298,7 +298,7 @@ func (p *Provider) newGauge(name string, labelValues ...string) kmetrics.Gauge {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	labelValues = append(labelValues, p.defaultTags...)
+	labelValues = p.applyDefaultTags(labelValues...)
 
 	k := keyName(name, labelValues...)
 	if _, ok := p.gauges[k]; !ok {
@@ -326,7 +326,7 @@ func (p *Provider) newHistogram(name string, buckets int, percentilePrefix strin
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	labelValues = append(labelValues, p.defaultTags...)
+	labelValues = p.applyDefaultTags(labelValues...)
 
 	k := keyName(name, labelValues...)
 	if _, ok := p.histograms[k]; !ok {
@@ -352,6 +352,25 @@ func (p *Provider) NewCardinalityCounter(name string) xmetrics.CardinalityCounte
 	defer p.mu.Unlock()
 	p.cardinalityCounters = append(p.cardinalityCounters, c)
 	return c
+}
+
+func (p *Provider) applyDefaultTags(labelValues ...string) []string {
+	if len(labelValues) > len(p.defaultTags) {
+		contained := true
+
+		for idx, v := range p.defaultTags {
+			if labelValues[idx] != v {
+				contained = false
+				break
+			}
+		}
+
+		if contained {
+			return labelValues
+		}
+	}
+
+	return append(p.defaultTags, labelValues...)
 }
 
 // Histogram adapts go-kit/Heroku/Librato's ideas of histograms. It

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -263,14 +263,12 @@ func (p *Provider) metricName(name string, labelValues ...string) string {
 // report use the WithResetCounters option function, otherwise the counter's
 // value will increase until restart.
 func (p *Provider) NewCounter(name string) kmetrics.Counter {
-	return p.newCounter(prefixName(p.prefix, name))
+	return p.newCounter(prefixName(p.prefix, name), p.defaultTags...)
 }
 
 func (p *Provider) newCounter(name string, labelValues ...string) kmetrics.Counter {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	labelValues = p.applyDefaultTags(labelValues...)
 
 	k := keyName(name, labelValues...)
 	if _, ok := p.counters[k]; !ok {
@@ -291,14 +289,12 @@ func (p *Provider) newCounter(name string, labelValues ...string) kmetrics.Count
 
 // NewGauge that will be reported by the provider.
 func (p *Provider) NewGauge(name string) kmetrics.Gauge {
-	return p.newGauge(prefixName(p.prefix, name))
+	return p.newGauge(prefixName(p.prefix, name), p.defaultTags...)
 }
 
 func (p *Provider) newGauge(name string, labelValues ...string) kmetrics.Gauge {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	labelValues = p.applyDefaultTags(labelValues...)
 
 	k := keyName(name, labelValues...)
 	if _, ok := p.gauges[k]; !ok {
@@ -319,14 +315,12 @@ func (p *Provider) newGauge(name string, labelValues ...string) kmetrics.Gauge {
 
 // NewHistogram that will be reported by the provider.
 func (p *Provider) NewHistogram(name string, buckets int) kmetrics.Histogram {
-	return p.newHistogram(prefixName(p.prefix, name), buckets, p.percentilePrefix)
+	return p.newHistogram(prefixName(p.prefix, name), buckets, p.percentilePrefix, p.defaultTags...)
 }
 
 func (p *Provider) newHistogram(name string, buckets int, percentilePrefix string, labelValues ...string) kmetrics.Histogram {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	labelValues = p.applyDefaultTags(labelValues...)
 
 	k := keyName(name, labelValues...)
 	if _, ok := p.histograms[k]; !ok {
@@ -352,25 +346,6 @@ func (p *Provider) NewCardinalityCounter(name string) xmetrics.CardinalityCounte
 	defer p.mu.Unlock()
 	p.cardinalityCounters = append(p.cardinalityCounters, c)
 	return c
-}
-
-func (p *Provider) applyDefaultTags(labelValues ...string) []string {
-	if len(labelValues) > len(p.defaultTags) {
-		contained := true
-
-		for idx, v := range p.defaultTags {
-			if labelValues[idx] != v {
-				contained = false
-				break
-			}
-		}
-
-		if contained {
-			return labelValues
-		}
-	}
-
-	return append(p.defaultTags, labelValues...)
 }
 
 // Histogram adapts go-kit/Heroku/Librato's ideas of histograms. It

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -55,7 +55,7 @@ type Provider struct {
 
 	now         func() time.Time
 	tagsEnabled bool
-	batcher     batcher
+	batcher     *batcher
 
 	once          sync.Once
 	done, stopped chan struct{}
@@ -103,8 +103,7 @@ func WithSSA() OptionFunc {
 // is to not allow it, and fall back to just sources.
 func WithTags() OptionFunc {
 	return func(p *Provider) {
-		p.tagsEnabled = true
-		p.batcher = &taggedBatcher{p: p}
+		p.batcher.tagsEnabled = true
 	}
 }
 
@@ -187,9 +186,7 @@ func New(URL *url.URL, interval time.Duration, opts ...OptionFunc) metrics.Provi
 		now: time.Now,
 	}
 
-	// Defaults to the old batcher. Can be overridden if WithTags
-	// is called.
-	p.batcher = &oldBatcher{p: &p}
+	p.batcher = &batcher{p: &p}
 
 	for _, opt := range opts {
 		opt(&p)

--- a/go-kit/metrics/provider/librato/librato_test.go
+++ b/go-kit/metrics/provider/librato/librato_test.go
@@ -341,7 +341,7 @@ func TestLibratoSingleReportWithLabelValuesOnTagBasedAccount(t *testing.T) {
 		t.Fatal("unexpected error reporting metrics", err)
 	}
 
-	p := New(u, doesntmatter, WithTags(), WithSource("test.source"), WithErrorHandler(errs))
+	p := New(u, doesntmatter, WithTags("app", "myapp"), WithSource("test.source"), WithErrorHandler(errs))
 	c := p.NewCounter("test.counter")
 	g := p.NewGauge("test.gauge")
 	h := p.NewHistogram("test.histogram", DefaultBucketCount)

--- a/go-kit/metrics/provider/librato/librato_test.go
+++ b/go-kit/metrics/provider/librato/librato_test.go
@@ -849,10 +849,11 @@ func TestGaugeLabelValues(t *testing.T) {
 
 func TestCounterNaming(t *testing.T) {
 	tests := []struct {
-		name     string
-		p        *Provider
-		fn       func(p *Provider) kmetrics.Counter
-		wantName string
+		name            string
+		p               *Provider
+		fn              func(p *Provider) kmetrics.Counter
+		wantName        string
+		wantLabelValues []string
 	}{
 		{
 			name:     "no prefix, no label values",
@@ -869,24 +870,43 @@ func TestCounterNaming(t *testing.T) {
 		},
 
 		{
-			name:     "no prefix, with label values",
-			p:        &Provider{counters: make(map[string]*Counter)},
-			fn:       func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
-			wantName: "my-counter",
+			name:            "no prefix, with label values",
+			p:               &Provider{counters: make(map[string]*Counter)},
+			fn:              func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
+			wantName:        "my-counter",
+			wantLabelValues: []string{"region", "us"},
 		},
 
 		{
-			name:     "no prefix, with label values, tags enabled",
-			p:        &Provider{counters: make(map[string]*Counter), tagsEnabled: true},
-			fn:       func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
-			wantName: "my-counter",
+			name:            "no prefix, with label values, tags enabled",
+			p:               &Provider{counters: make(map[string]*Counter), tagsEnabled: true},
+			fn:              func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
+			wantName:        "my-counter",
+			wantLabelValues: []string{"region", "us"},
 		},
 
 		{
-			name:     "with prefix, with label values, tags enabled",
-			p:        &Provider{prefix: "my-prefix", counters: make(map[string]*Counter), tagsEnabled: true},
-			fn:       func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
-			wantName: "my-prefix.my-counter",
+			name:            "with prefix, with label values, tags enabled",
+			p:               &Provider{prefix: "my-prefix", counters: make(map[string]*Counter), tagsEnabled: true},
+			fn:              func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
+			wantName:        "my-prefix.my-counter",
+			wantLabelValues: []string{"region", "us"},
+		},
+
+		{
+			name:            "no prefix, with label values, tags enabled, default tags",
+			p:               &Provider{counters: make(map[string]*Counter), tagsEnabled: true, defaultTags: []string{"sys", "foo"}},
+			fn:              func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
+			wantName:        "my-counter",
+			wantLabelValues: []string{"sys", "foo", "region", "us"},
+		},
+
+		{
+			name:            "with prefix, with label values, tags enabled, default tags",
+			p:               &Provider{prefix: "my-prefix", counters: make(map[string]*Counter), tagsEnabled: true, defaultTags: []string{"sys", "foo"}},
+			fn:              func(p *Provider) kmetrics.Counter { return p.NewCounter("my-counter").With("region", "us") },
+			wantName:        "my-prefix.my-counter",
+			wantLabelValues: []string{"sys", "foo", "region", "us"},
 		},
 	}
 
@@ -900,16 +920,21 @@ func TestCounterNaming(t *testing.T) {
 			if got := counter.(*Counter).Counter.Name; test.wantName != got {
 				t.Fatalf("want name: %q, got %q", test.wantName, got)
 			}
+
+			if got := counter.(*Counter).LabelValues(); !reflect.DeepEqual(test.wantLabelValues, got) {
+				t.Fatalf("want label values: %q, got %q", test.wantLabelValues, got)
+			}
 		})
 	}
 }
 
 func TestGaugeNaming(t *testing.T) {
 	tests := []struct {
-		name     string
-		p        *Provider
-		fn       func(p *Provider) kmetrics.Gauge
-		wantName string
+		name            string
+		p               *Provider
+		fn              func(p *Provider) kmetrics.Gauge
+		wantName        string
+		wantLabelValues []string
 	}{
 		{
 			name:     "no prefix, no label values",
@@ -926,24 +951,43 @@ func TestGaugeNaming(t *testing.T) {
 		},
 
 		{
-			name:     "no prefix, with label values",
-			p:        &Provider{gauges: make(map[string]*Gauge)},
-			fn:       func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
-			wantName: "my-gauge",
+			name:            "no prefix, with label values",
+			p:               &Provider{gauges: make(map[string]*Gauge)},
+			fn:              func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
+			wantName:        "my-gauge",
+			wantLabelValues: []string{"region", "us"},
 		},
 
 		{
-			name:     "no prefix, with label values, tags enabled",
-			p:        &Provider{gauges: make(map[string]*Gauge), tagsEnabled: true},
-			fn:       func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
-			wantName: "my-gauge",
+			name:            "no prefix, with label values, tags enabled",
+			p:               &Provider{gauges: make(map[string]*Gauge), tagsEnabled: true},
+			fn:              func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
+			wantName:        "my-gauge",
+			wantLabelValues: []string{"region", "us"},
 		},
 
 		{
-			name:     "with prefix, with label values, tags enabled",
-			p:        &Provider{prefix: "my-prefix", gauges: make(map[string]*Gauge), tagsEnabled: true},
-			fn:       func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
-			wantName: "my-prefix.my-gauge",
+			name:            "with prefix, with label values, tags enabled",
+			p:               &Provider{prefix: "my-prefix", gauges: make(map[string]*Gauge), tagsEnabled: true},
+			fn:              func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
+			wantName:        "my-prefix.my-gauge",
+			wantLabelValues: []string{"region", "us"},
+		},
+
+		{
+			name:            "no prefix, with label values, tags enabled, default tags",
+			p:               &Provider{gauges: make(map[string]*Gauge), tagsEnabled: true, defaultTags: []string{"sys", "foo"}},
+			fn:              func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
+			wantName:        "my-gauge",
+			wantLabelValues: []string{"sys", "foo", "region", "us"},
+		},
+
+		{
+			name:            "with prefix, with label values, tags enabled, default tags",
+			p:               &Provider{prefix: "my-prefix", gauges: make(map[string]*Gauge), tagsEnabled: true, defaultTags: []string{"sys", "foo"}},
+			fn:              func(p *Provider) kmetrics.Gauge { return p.NewGauge("my-gauge").With("region", "us") },
+			wantName:        "my-prefix.my-gauge",
+			wantLabelValues: []string{"sys", "foo", "region", "us"},
 		},
 	}
 
@@ -957,16 +1001,21 @@ func TestGaugeNaming(t *testing.T) {
 			if got := gauge.(*Gauge).Gauge.Name; test.wantName != got {
 				t.Fatalf("want name: %q, got %q", test.wantName, got)
 			}
+
+			if got := gauge.(*Gauge).LabelValues(); !reflect.DeepEqual(test.wantLabelValues, got) {
+				t.Fatalf("want label values: %q, got %q", test.wantLabelValues, got)
+			}
 		})
 	}
 }
 
 func TestHistogramNaming(t *testing.T) {
 	tests := []struct {
-		name     string
-		p        *Provider
-		fn       func(p *Provider) kmetrics.Histogram
-		wantName string
+		name            string
+		p               *Provider
+		fn              func(p *Provider) kmetrics.Histogram
+		wantName        string
+		wantLabelValues []string
 	}{
 		{
 			name:     "no prefix, no label values",
@@ -983,24 +1032,43 @@ func TestHistogramNaming(t *testing.T) {
 		},
 
 		{
-			name:     "no prefix, with label values",
-			p:        &Provider{histograms: make(map[string]*Histogram)},
-			fn:       func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
-			wantName: "my-histogram",
+			name:            "no prefix, with label values",
+			p:               &Provider{histograms: make(map[string]*Histogram)},
+			fn:              func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
+			wantName:        "my-histogram",
+			wantLabelValues: []string{"region", "us"},
 		},
 
 		{
-			name:     "no prefix, with label values, tags enabled",
-			p:        &Provider{histograms: make(map[string]*Histogram), tagsEnabled: true},
-			fn:       func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
-			wantName: "my-histogram",
+			name:            "no prefix, with label values, tags enabled",
+			p:               &Provider{histograms: make(map[string]*Histogram), tagsEnabled: true},
+			fn:              func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
+			wantName:        "my-histogram",
+			wantLabelValues: []string{"region", "us"},
 		},
 
 		{
-			name:     "with prefix, with label values, tags enabled",
-			p:        &Provider{prefix: "my-prefix", histograms: make(map[string]*Histogram), tagsEnabled: true},
-			fn:       func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
-			wantName: "my-prefix.my-histogram",
+			name:            "with prefix, with label values, tags enabled",
+			p:               &Provider{prefix: "my-prefix", histograms: make(map[string]*Histogram), tagsEnabled: true},
+			fn:              func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
+			wantName:        "my-prefix.my-histogram",
+			wantLabelValues: []string{"region", "us"},
+		},
+
+		{
+			name:            "no prefix, with label values, tags enabled, default tags",
+			p:               &Provider{histograms: make(map[string]*Histogram), tagsEnabled: true, defaultTags: []string{"sys", "foo"}},
+			fn:              func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
+			wantName:        "my-histogram",
+			wantLabelValues: []string{"sys", "foo", "region", "us"},
+		},
+
+		{
+			name:            "with prefix, with label values, tags enabled, default tags",
+			p:               &Provider{prefix: "my-prefix", histograms: make(map[string]*Histogram), tagsEnabled: true, defaultTags: []string{"sys", "foo"}},
+			fn:              func(p *Provider) kmetrics.Histogram { return p.NewHistogram("my-histogram", 50).With("region", "us") },
+			wantName:        "my-prefix.my-histogram",
+			wantLabelValues: []string{"sys", "foo", "region", "us"},
 		},
 	}
 
@@ -1013,6 +1081,10 @@ func TestHistogramNaming(t *testing.T) {
 			histogram := test.fn(test.p)
 			if got := histogram.(*Histogram).name; test.wantName != got {
 				t.Fatalf("want name: %q, got %q", test.wantName, got)
+			}
+
+			if got := histogram.(*Histogram).labelValues; !reflect.DeepEqual(test.wantLabelValues, got) {
+				t.Fatalf("want label values: %q, got %q", test.wantLabelValues, got)
 			}
 		})
 	}


### PR DESCRIPTION
Combine the `batcher` types into a single struct type with a `batchMetrics` for tagless and `batchMeasurements` for tagged metrics.

Add tag arguments to the `librato.WithTags` opt func. Tags specified in the `WithTags` call are included in all metrics created by the provider.