### PR TITLE
 go-kit/metrics/provider/librato: fix tagged histogram metric name, only sample used metrics

### DIFF
--- a/go-kit/metrics/provider/librato/batcher.go
+++ b/go-kit/metrics/provider/librato/batcher.go
@@ -16,12 +16,10 @@ const (
 
 type batcher struct {
 	p *Provider
-
-	tagsEnabled bool
 }
 
 func (b *batcher) Batch(u *url.URL, interval time.Duration) ([]*http.Request, error) {
-	if b.tagsEnabled {
+	if b.p.tagsEnabled {
 		return b.batchMeasurements(u, interval)
 	}
 	return b.batchMetrics(u, interval)

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -452,6 +452,14 @@ func (h *Histogram) SumSq() float64 {
 type Counter struct {
 	*generic.Counter
 	p *Provider
+
+	used bool
+}
+
+// Add implements Counter.
+func (c *Counter) Add(delta float64) {
+	c.Counter.Add(delta)
+	c.used = true
 }
 
 // With returns a Counter with the label values applied. Depending on whether
@@ -470,6 +478,18 @@ func (c *Counter) metricName() string {
 type Gauge struct {
 	*generic.Gauge
 	p *Provider
+
+	used bool
+}
+
+func (g *Gauge) Set(value float64) {
+	g.Gauge.Set(value)
+	g.used = true
+}
+
+func (g *Gauge) Add(delta float64) {
+	g.Gauge.Add(delta)
+	g.used = true
 }
 
 // With returns a Gauge with the label values applied. Depending on whether

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -453,7 +453,7 @@ type Counter struct {
 	*generic.Counter
 	p *Provider
 
-	used bool
+	used bool // allows batcher to ignore counters used only to create labeled counters
 }
 
 // Add implements Counter.
@@ -479,14 +479,16 @@ type Gauge struct {
 	*generic.Gauge
 	p *Provider
 
-	used bool
+	used bool // allows batcher to ignore gauges used only to create labeled counters
 }
 
+// Set implements Gauge.
 func (g *Gauge) Set(value float64) {
 	g.Gauge.Set(value)
 	g.used = true
 }
 
+// Add implements Gauge.
 func (g *Gauge) Add(delta float64) {
 	g.Gauge.Add(delta)
 	g.used = true

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -104,7 +104,7 @@ func WithSSA() OptionFunc {
 // is to not allow it, and fall back to just sources.
 func WithTags(labelValues ...string) OptionFunc {
 	return func(p *Provider) {
-		p.batcher.tagsEnabled = true
+		p.tagsEnabled = true
 		p.defaultTags = append(p.defaultTags, labelValues...)
 	}
 }

--- a/go-kit/metrics/provider/librato/sample.go
+++ b/go-kit/metrics/provider/librato/sample.go
@@ -101,7 +101,7 @@ func (p *Provider) sample(period int) []measurement {
 		}
 
 		measurements = append(measurements, measurement{
-			Name:       c.Name,
+			Name:       c.metricName(),
 			Time:       ts.Unix(),
 			Period:     period,
 			Count:      1,
@@ -119,7 +119,7 @@ func (p *Provider) sample(period int) []measurement {
 	for _, g := range p.gauges {
 		v := g.Value()
 		measurements = append(measurements, measurement{
-			Name:       g.Name,
+			Name:       g.metricName(),
 			Time:       ts.Unix(),
 			Period:     period,
 			Count:      1,

--- a/go-kit/metrics/provider/librato/sample.go
+++ b/go-kit/metrics/provider/librato/sample.go
@@ -93,6 +93,10 @@ func (p *Provider) sample(period int) []measurement {
 	// Assemble all the data we have to send
 	var measurements []measurement
 	for _, c := range p.counters {
+		if !c.used {
+			continue
+		}
+
 		var v float64
 		if p.resetCounters {
 			v = c.ValueReset()
@@ -117,6 +121,10 @@ func (p *Provider) sample(period int) []measurement {
 	}
 
 	for _, g := range p.gauges {
+		if !g.used {
+			continue
+		}
+
 		v := g.Value()
 		measurements = append(measurements, measurement{
 			Name:       g.metricName(),


### PR DESCRIPTION
Ignore unused (unobserved) metrics, which happens when an observer is only used to create tagged observers via `.With` method calls. Remove the `tagsEnabled` field from `batcher`, which was breaking tagging as it never was set. Use the `metricName()` helper to construct `Gauge` and `Counter` metric names.