### PR TITLE
go-kit/metrics: fix zero cap panic in HLLCounter.With

### DIFF
--- a/go-kit/metrics/hllcounter.go
+++ b/go-kit/metrics/hllcounter.go
@@ -36,7 +36,7 @@ func NewHLLCounter(name string) *HLLCounter {
 // With returns a new UniqueCounter with the passed in label values merged
 // with the previous label values. The counter's values are copied.
 func (c *HLLCounter) With(labelValues ...string) CardinalityCounter {
-	nlv := make([]string, len(c.lvs)+len(labelValues), 0)
+	nlv := make([]string, 0, len(c.lvs)+len(labelValues))
 	nlv = append(nlv, c.lvs...)
 	nlv = append(nlv, labelValues...)
 

--- a/go-kit/metrics/hllcounter_test.go
+++ b/go-kit/metrics/hllcounter_test.go
@@ -10,6 +10,11 @@ import (
 	"testing"
 )
 
+func TestHLLCounterWith(t *testing.T) {
+	c := NewHLLCounter("foo").With("bar", "baz")
+	c.Insert([]byte("foo"))
+}
+
 func TestHLLCounterEstimate(t *testing.T) {
 	c := NewHLLCounter("foo")
 	c.Insert([]byte("foo"))


### PR DESCRIPTION
Swap the zero size cap for the len argument to avoid a panic when cap is zero.