### PR TITLE
 go-kit/metrics/provider/librato: add CardinalityCounter wrapper type

### DIFF
--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -56,7 +56,6 @@ type Provider struct {
 	now         func() time.Time
 	tagsEnabled bool
 	defaultTags []string
-	batcher     *batcher
 
 	once          sync.Once
 	done, stopped chan struct{}
@@ -187,8 +186,6 @@ func New(URL *url.URL, interval time.Duration, opts ...OptionFunc) metrics.Provi
 
 		now: time.Now,
 	}
-
-	p.batcher = &batcher{p: &p}
 
 	for _, opt := range opts {
 		opt(&p)

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -349,7 +349,7 @@ func (p *Provider) newCardinalityCounter(name string, labelValues ...string) xme
 	k := keyName(name, labelValues...)
 	if _, ok := p.cardinalityCounters[k]; !ok {
 		c := &CardinalityCounter{
-			HLLCounter: xmetrics.NewHLLCounter(prefixName(p.prefix, name)),
+			HLLCounter: xmetrics.NewHLLCounter(name).With(labelValues...).(*xmetrics.HLLCounter),
 			p:          p,
 		}
 

--- a/go-kit/metrics/provider/librato/librato_test.go
+++ b/go-kit/metrics/provider/librato/librato_test.go
@@ -345,11 +345,13 @@ func TestLibratoSingleReportWithLabelValuesOnTagBasedAccount(t *testing.T) {
 	c := p.NewCounter("test.counter")
 	g := p.NewGauge("test.gauge")
 	h := p.NewHistogram("test.histogram", DefaultBucketCount)
+	cc := p.NewCardinalityCounter("test.cardinality-counter")
 	c.With("region", "us").With("space", "myspace").Add(float64(time.Now().Unix())) // increasing value
 	g.With("region", "us").With("space", "myspace").Set(rand.Float64())
 	h.With("region", "us").With("space", "myspace").Observe(10)
 	h.With("region", "us").With("space", "myspace").Observe(100)
 	h.With("region", "us").With("space", "myspace").Observe(150)
+	cc.With("region", "us").With("space", "myspace").Insert([]byte("foo.bar"))
 	p.Stop() // does a final report
 }
 

--- a/go-kit/metrics/provider/librato/librato_test.go
+++ b/go-kit/metrics/provider/librato/librato_test.go
@@ -73,7 +73,7 @@ func TestLibratoReportRequestDebugging(t *testing.T) {
 			p := New(u, doesntmatter, func(p *Provider) { p.requestDebugging = debug }).(*Provider)
 			p.Stop()
 			p.NewCounter("foo").Add(1) // need at least one metric in order to report
-			reqs, err := p.batcher.Batch(u, doesntmatter)
+			reqs, err := p.Batch(u, doesntmatter)
 			if err != nil {
 				t.Fatal("unexpected error", err)
 			}
@@ -640,7 +640,7 @@ func TestWithResetCounters(t *testing.T) {
 
 			foo := p.NewCounter("foo")
 			foo.Add(1)
-			reqs, err := p.batcher.Batch(u, doesntmatter)
+			reqs, err := p.Batch(u, doesntmatter)
 			if err != nil {
 				t.Fatal("unexpected error batching", err)
 			}
@@ -683,7 +683,7 @@ func TestWithResetCountersCardinalityCounters(t *testing.T) {
 			foo := p.NewCardinalityCounter("foo")
 			foo.Insert([]byte("foo"))
 
-			reqs, err := p.batcher.Batch(u, doesntmatter)
+			reqs, err := p.Batch(u, doesntmatter)
 			if err != nil {
 				t.Fatal("unexpected error batching", err)
 			}

--- a/go-kit/metrics/provider/librato/report.go
+++ b/go-kit/metrics/provider/librato/report.go
@@ -62,7 +62,7 @@ func (e Error) Error() string {
 // reportWithRetry the metrics to the url, every interval, with max retries.
 func (p *Provider) reportWithRetry(u *url.URL, interval time.Duration) {
 	nu := *u // copy the url
-	requests, err := p.batcher.Batch(&nu, interval)
+	requests, err := p.Batch(&nu, interval)
 	if err != nil {
 		p.errorHandler(err)
 		return

--- a/go-kit/metrics/provider/librato/sample.go
+++ b/go-kit/metrics/provider/librato/sample.go
@@ -147,6 +147,10 @@ func (p *Provider) sample(period int) []measurement {
 	}
 
 	for _, c := range p.cardinalityCounters {
+		if !c.used {
+			continue
+		}
+
 		var v float64
 		if p.resetCounters {
 			v = float64(c.EstimateReset())
@@ -154,7 +158,7 @@ func (p *Provider) sample(period int) []measurement {
 			v = float64(c.Estimate())
 		}
 		measurements = append(measurements, measurement{
-			Name:       c.Name,
+			Name:       c.metricName(),
 			Time:       ts.Unix(),
 			Period:     period,
 			Count:      1,


### PR DESCRIPTION
Add a `librato.CardinalityCounter` struct that wraps the `(github.com/heroku/x/go-kit/metrics).HLLCounter` type. The wrapper type tracks usage to avoid submitting unused metrics, and handles tags added via `With` method calls.