### PR TITLE
Librato: add internal metrics

### DIFF
--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -203,9 +203,9 @@ func New(URL *url.URL, interval time.Duration, opts ...OptionFunc) metrics.Provi
 		}
 	}
 
-	p.measurements = p.NewGauge("internal.measurements")
-	p.ratelimitAgg = p.NewGauge("internal.ratelimit-aggregate")
-	p.ratelimitStd = p.NewGauge("internal.ratelimit-standard")
+	p.measurements = p.NewGauge("go-kit.measurements")
+	p.ratelimitAgg = p.NewGauge("go-kit.ratelimit-aggregate")
+	p.ratelimitStd = p.NewGauge("go-kit.ratelimit-standard")
 
 	go func() {
 		t := time.NewTicker(interval)

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -65,6 +65,10 @@ type Provider struct {
 	gauges              map[string]*Gauge
 	histograms          map[string]*Histogram
 	cardinalityCounters map[string]*CardinalityCounter
+
+	measurements kmetrics.Gauge
+	ratelimitAgg kmetrics.Gauge
+	ratelimitStd kmetrics.Gauge
 }
 
 // OptionFunc used to set options on a librato provider
@@ -198,6 +202,10 @@ func New(URL *url.URL, interval time.Duration, opts ...OptionFunc) metrics.Provi
 			return nil
 		}
 	}
+
+	p.measurements = p.NewGauge("internal.measurements")
+	p.ratelimitAgg = p.NewGauge("internal.ratelimit-aggregate")
+	p.ratelimitStd = p.NewGauge("internal.ratelimit-standard")
 
 	go func() {
 		t := time.NewTicker(interval)

--- a/go-kit/metrics/provider/librato/librato_test.go
+++ b/go-kit/metrics/provider/librato/librato_test.go
@@ -1091,3 +1091,45 @@ func TestHistogramNaming(t *testing.T) {
 		})
 	}
 }
+
+func TestRemainingRateLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{
+			name:  "default",
+			input: "limit=600000,remaining=599998,reset=1531370400",
+			want:  599998,
+		},
+		{
+			name:  "at beginning",
+			input: "remaining=599998,reset=1531370400,limit=600000",
+			want:  599998,
+		},
+		{
+			name:  "at end",
+			input: "reset=1531370400,limit=600000,remaining=599998",
+			want:  599998,
+		},
+		{
+			name:  "empty",
+			input: "",
+			want:  -1,
+		},
+		{
+			name:  "just remaining",
+			input: "remaining=599998",
+			want:  599998,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := remainingRateLimit(test.input); test.want != got {
+				t.Errorf("want %d got %d", test.want, got)
+			}
+		})
+	}
+}

--- a/go-kit/metrics/provider/librato/librato_test.go
+++ b/go-kit/metrics/provider/librato/librato_test.go
@@ -1092,6 +1092,38 @@ func TestHistogramNaming(t *testing.T) {
 	}
 }
 
+func TestInternalMetrics(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Librato-RateLimit-Agg", "remaining=101")
+		w.Header().Set("X-Librato-RateLimit-Std", "remaining=102")
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL)
+
+	p := New(u, 20*time.Second).(*Provider)
+
+	c := p.NewCounter("my.counter")
+	c.Add(1)
+
+	g := p.NewGauge("my.gauge")
+	g.Set(1)
+
+	p.reportWithRetry(u, 20*time.Second)
+
+	if got := p.ratelimitAgg.(*Gauge).Value(); got != 101 {
+		t.Fatalf("want agg rate limit 101, got %f", got)
+	}
+
+	if got := p.ratelimitStd.(*Gauge).Value(); got != 102 {
+		t.Fatalf("want std rate limit 101, got %f", got)
+	}
+
+	if got := p.measurements.(*Gauge).Value(); got != 2 {
+		t.Fatalf("want measurements gauge to be 2, got %f", got)
+	}
+}
+
 func TestRemainingRateLimit(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/go-kit/metrics/provider/librato/sample.go
+++ b/go-kit/metrics/provider/librato/sample.go
@@ -173,6 +173,10 @@ func (p *Provider) sample(period int) []measurement {
 		})
 	}
 
+	if p.measurements != nil {
+		p.measurements.Set(float64(len(measurements)))
+	}
+
 	return measurements
 }
 


### PR DESCRIPTION
## Context

We want internal metrics to be reported. For now, these are limited to:

1. The rate limits we're seeing
2. The total measurements sampled during reporting.

These measurements will allow us to monitor the provider itself (e.g. are we sending too many measurements) and potentially build alerts around them.

Connects to https://github.com/heroku/cedar/issues/2479