### PR TITLE
librato: fix authentication with retry and debug enabled

### DIFF
--- a/go-kit/metrics/provider/librato/librato_test.go
+++ b/go-kit/metrics/provider/librato/librato_test.go
@@ -112,6 +112,12 @@ type temporary interface {
 func TestLibratoRetriesWithErrors(t *testing.T) {
 	var retried int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "user" || pass != "pass" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
 		retried++
 		b, err := io.Copy(ioutil.Discard, r.Body)
 		if err != nil {
@@ -128,6 +134,7 @@ func TestLibratoRetriesWithErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	u.User = url.UserPassword("user", "pass")
 
 	var totalErrors, temporaryErrors, finalErrors int
 	expectedRetries := 3

--- a/go-kit/metrics/provider/librato/report.go
+++ b/go-kit/metrics/provider/librato/report.go
@@ -124,14 +124,7 @@ func (p *Provider) report(req *http.Request) error {
 			rateLimitStd: resp.Header.Get("X-Librato-RateLimit-Std"),
 		}
 		if p.requestDebugging {
-			req.Header = scrub.Header(req.Header)
-
-			// Best effort, but don't fail on error
-			if b, err := req.GetBody(); err == nil {
-				req.Body = b
-			}
-			d, _ := httputil.DumpRequestOut(req, true)
-			e.dumpedRequest = string(d)
+			e.dumpedRequest = dumpRequest(req)
 		}
 
 		return e
@@ -151,4 +144,19 @@ func remainingRateLimit(s string) int {
 		}
 	}
 	return -1
+}
+
+func dumpRequest(req *http.Request) string {
+	header := req.Header
+	defer func() { req.Header = header }()
+
+	req.Header = scrub.Header(header)
+
+	// Best effort, but don't fail on error
+	if b, err := req.GetBody(); err == nil {
+		req.Body = b
+	}
+
+	d, _ := httputil.DumpRequestOut(req, true)
+	return string(d)
 }


### PR DESCRIPTION
We've observed in our systems that retries never succeed, but instead
always return a `401 Unauthorized` after the failure.

It turns out when using both WithRetries and WithRequestDebugging the
authentication was being dropped before retry attempts were made.

This updates the reporter to preserve headers when capturing debug
information so that subsequent retries can succeed.