### PR TITLE
get rid of garyburd redigo in favor of gomodule: fixes #32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/aws/aws-sdk-go v1.13.10
 	github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
-	github.com/garyburd/redigo v1.6.0
 	github.com/go-chi/chi v3.3.2+incompatible
 	github.com/go-ini/ini v1.33.0 // indirect
 	github.com/go-kit/kit v0.6.0

--- a/hredis/redigo/redigo.go
+++ b/hredis/redigo/redigo.go
@@ -3,7 +3,7 @@ package redigo
 import (
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // WaitFunc to be executed occasionally by something that is waiting.


### PR DESCRIPTION
Addresses the non-controversial change from #34  that got killed when I closed that pr.