### PR TITLE
Forward request ids

### DIFF
--- a/grpc/grpcclient/dial.go
+++ b/grpc/grpcclient/dial.go
@@ -1,8 +1,10 @@
 package grpcclient
 
 import (
+	"context"
 	"net/url"
 
+	"github.com/heroku/x/grpc/requestid"
 	"github.com/heroku/x/tlsconfig"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -22,4 +24,14 @@ func Credentials(serverURL string, caCerts [][]byte, clientCert, clientKey []byt
 	cfg.ServerName = uri.Host
 
 	return grpc.WithTransportCredentials(credentials.NewTLS(cfg)), nil
+}
+
+// AppendOutgoingRequestID reads the incoming Request-ID from the context and appends it to the
+// outgoing context. Forwarding Request-IDs from gRPC service to service allows for request
+// tracking across any number of services.
+func AppendOutgoingRequestID() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = requestid.AppendToOutgoingContext(ctx)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
 }

--- a/grpc/grpchttp/request_id.go
+++ b/grpc/grpchttp/request_id.go
@@ -5,13 +5,14 @@ import (
 	"net/http"
 
 	"github.com/heroku/x/grpc/requestid"
+	httprequestid "github.com/heroku/x/requestid"
 	"google.golang.org/grpc/metadata"
 )
 
 // RequestIDAnnotator returns gRPC metadata with the Request-Id header if
 // present. The request ID can be later retrieved by requestid.FromContext.
 func RequestIDAnnotator(ctx context.Context, r *http.Request) metadata.MD {
-	if id := r.Header.Get("Request-Id"); id != "" {
+	if id := httprequestid.Get(r); id != "" {
 		return requestid.NewMetadata(id)
 	}
 

--- a/grpc/requestid/requestid.go
+++ b/grpc/requestid/requestid.go
@@ -29,3 +29,13 @@ func FromContext(ctx context.Context) (string, bool) {
 func NewMetadata(id string) metadata.MD {
 	return metadata.Pairs(metadataKey, id)
 }
+
+// AppendToOutgoingContext returns a context with the request-id added to the gRPC metadata.
+func AppendToOutgoingContext(ctx context.Context) context.Context {
+	id, ok := FromContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	return metadata.AppendToOutgoingContext(ctx, metadataKey, id)
+}

--- a/grpc/requestid/requestid_test.go
+++ b/grpc/requestid/requestid_test.go
@@ -42,3 +42,18 @@ func TestFromContext_InvalidMetadata(t *testing.T) {
 		t.Fatalf("got id from invalid context")
 	}
 }
+
+func TestAppendToOutgoingContext(t *testing.T) {
+	requestID := "request-1"
+	ctx := metadata.NewIncomingContext(context.Background(), NewMetadata(requestID))
+	ctx = AppendToOutgoingContext(ctx)
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("no id for annotated context")
+	}
+
+	id := md[metadataKey][0]
+	if id != requestID {
+		t.Fatalf("got request-id %q; wanted %q", id, requestID)
+	}
+}

--- a/requestid/requestid.go
+++ b/requestid/requestid.go
@@ -1,0 +1,18 @@
+package requestid
+
+import "net/http"
+
+var requestIDKeys = []string{
+	"Request-ID", "X-Request-ID",
+}
+
+// Get reads the Request-ID and X-Request-ID HTTP header from an `*http.Request`
+// If no header is set, an empty string is returned
+func Get(r *http.Request) string {
+	for _, try := range requestIDKeys {
+		if id := r.Header.Get(try); id != "" {
+			return id
+		}
+	}
+	return ""
+}

--- a/requestid/requestid_test.go
+++ b/requestid/requestid_test.go
@@ -1,0 +1,60 @@
+package requestid
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{
+			name:    "send Request-ID",
+			headers: map[string]string{"Request-ID": "request-id-value"},
+			want:    "request-id-value",
+		},
+		{
+			name:    "send X-Request-ID",
+			headers: map[string]string{"X-Request-ID": "x-request-id-value"},
+			want:    "x-request-id-value",
+		},
+		{
+			name: "send Request-ID and X-Request-ID. Prioritize Request-ID",
+			headers: map[string]string{
+				"Request-ID":   "request-id-value",
+				"X-Request-ID": "x-request-id-value",
+			},
+			want: "request-id-value",
+		},
+		{
+			name: "send invalid request id header",
+			headers: map[string]string{
+				"request_id": "request_id_value",
+			},
+			want: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, err := http.NewRequest("GET", "http://example.com", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for k, v := range test.headers {
+				r.Header.Set(k, v)
+			}
+
+			got := Get(r)
+			if got != test.want {
+				t.Fatalf("unexpected request-id got %q; want %q", got, test.want)
+			}
+
+		})
+	}
+
+}


### PR DESCRIPTION
- Request IDs come in as header `X-Request-ID` and `Request-ID`. Added a method to handle both.
- Updated RequestIDAnnotator to use `requestid.Get` instead of looking for a single Request ID header.
- Added AppendToOutgoingContext to read the Request ID from the context and append it to gRPC's outgoing.
- Added AppendOutgoingRequestID gRPC client interceptor which uses AppendToOutgoingContext