### PR TITLE
logplex: Add encoding package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e
 	github.com/aws/aws-sdk-go v1.13.10
 	github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228
+	github.com/bmizerany/lpx v0.0.0-20130503172629-af85cf24c156
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/go-chi/chi v3.3.2+incompatible
 	github.com/go-ini/ini v1.33.0 // indirect
@@ -18,6 +19,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.9.0
 	github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/influxdata/go-syslog v0.0.0-20190814180256-831896502726
 	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 // indirect
 	github.com/joeshaw/envdecode v0.0.0-20180129163420-d5f34bca07f3
 	github.com/leesper/go_rng v0.0.0-20171009123644-5344a9259b21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/aws/aws-sdk-go v1.13.10 h1:tvcbplK9Z3loAz1Zlala0yFZxAHu7VCh1OzlPTOSUe
 github.com/aws/aws-sdk-go v1.13.10/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228 h1:6rB1A80KrH56CUeQMp1a4fzEw44N8Jum9rs1Fihv2tA=
 github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228/go.mod h1:IOXAcuKIFq/mDyuQ4wyJuJ79XLMsmLM+5RdQ+vWrL7o=
+github.com/bmizerany/lpx v0.0.0-20130503172629-af85cf24c156 h1:0ywL+47/N2nSZUMM4VUYMZus+FPVfXbbXb2qhGpzsS8=
+github.com/bmizerany/lpx v0.0.0-20130503172629-af85cf24c156/go.mod h1:sBo9Xky5Lv+sFCp5t1OH7lwY/qRcheGrbjsvb0FdUwM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -34,6 +36,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
@@ -46,6 +49,9 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb h1:EPRgaDqX
 github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/go-syslog v0.0.0-20190814180256-831896502726 h1:40VxjcPSryCrZ4dVr+8ywsM20P46BI7wMbOaRXcDZXY=
+github.com/influxdata/go-syslog v0.0.0-20190814180256-831896502726/go.mod h1:nfOHho8GEfBVl+hTcS1MzCMiM5WDo6Xh3KphW+Bn2sM=
+github.com/influxdata/go-syslog v1.0.1 h1:a/ARpnCDr/sX/hVH7dyQVi+COXlEzM4bNIoolOfw99Y=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joeshaw/envdecode v0.0.0-20180129163420-d5f34bca07f3 h1:Uzr4zoGuuuWdXeI65mG5l2yK2AbrifXXb5PtX/ym6Ig=
@@ -61,6 +67,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leesper/go_rng v0.0.0-20171009123644-5344a9259b21 h1:O75p5GUdUfhJqNCMM1ntthjtJCOHVa1lzMSfh5Qsa0Y=
 github.com/leesper/go_rng v0.0.0-20171009123644-5344a9259b21/go.mod h1:N0SVk0uhy+E1PZ3C9ctsPRlvOPAFPkCNlcPBDkt0N3U=
+github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165/go.mod h1:WZxr2/6a/Ar9bMDc2rN/LJrE/hF6bXE4LPyDSIxwAfg=
 github.com/lstoll/grpce v1.7.0 h1:/kwghyD9VpbCzZg7WQC4BRZRKnRPwwdj80qz7iZJ+/Q=
 github.com/lstoll/grpce v1.7.0/go.mod h1:XiCWl3R+avNCT7KsTjv3qCblgsSqd0SC4ymySrH226g=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=

--- a/logplex/encoding/encoder.go
+++ b/logplex/encoding/encoder.go
@@ -1,0 +1,144 @@
+package encoding
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// SyslogTimeFormat defines the exact time format used in our logs.
+const SyslogTimeFormat = "2006-01-02T15:04:05.999999-07:00"
+
+// L15Error is the message returned with an L15 error
+const L15Error = "L15: Error displaying log lines. Please try again."
+
+// ErrInvalidMessage returned when trying to encode an invalid syslog message
+var ErrInvalidMessage = errors.New("invalid message")
+
+// Encoder abstracts away how messages are written out
+type Encoder interface {
+	Encode(msg Message) error
+	KeepAlive() error
+}
+
+type plainEncoder struct {
+	w io.Writer
+}
+
+// NewPlain creates a plain encoder. It dumps the log message directly
+// without massaging it
+func NewPlain(w io.Writer) Encoder {
+	return &plainEncoder{w}
+}
+
+// Encode writes the message as-is
+func (p *plainEncoder) Encode(msg Message) error {
+	_, err := p.w.Write([]byte(messageToString(msg)))
+	return err
+}
+
+// KeepAlive sends a null byte.
+func (p *plainEncoder) KeepAlive() error {
+	_, err := p.w.Write([]byte{0})
+	return err
+}
+
+// sseEncoder wraps an io.Writer and provides convenience methods for SSE
+type sseEncoder struct {
+	w io.Writer
+}
+
+// NewSSE instantiates a new SSE encoder
+func NewSSE(w io.Writer) Encoder {
+	return &sseEncoder{w}
+}
+
+// KeepAlive sends a blank comment.
+func (s *sseEncoder) KeepAlive() error {
+	_, err := fmt.Fprintf(s.w, ": \n")
+	return err
+}
+
+// Encode assembles the message according to the SSE spec and writes it out
+func (s *sseEncoder) Encode(msg Message) error {
+	// Use time as the base for creating an ID, since we need monotonic numbers that we can potentially do offsets from
+	s.id(msg.Timestamp.Unix())
+	s.data(msg)
+	s.separator()
+	return nil
+}
+
+func (s *sseEncoder) id(id int64) {
+	fmt.Fprintf(s.w, "id: %v\n", id)
+}
+
+func (s *sseEncoder) data(msg Message) {
+	fmt.Fprint(s.w, "data: ")
+	fmt.Fprint(s.w, messageToString(msg))
+	fmt.Fprint(s.w, "\n")
+}
+
+func (s *sseEncoder) separator() {
+	fmt.Fprint(s.w, "\n\n")
+}
+
+func messageToString(msg Message) string {
+	return fmt.Sprintf("%s %s[%s]: %s", msg.Timestamp.Format(SyslogTimeFormat), msg.Application, msg.Process, msg.Message)
+}
+
+// Encode serializes a syslog message into their wire format ( octet-framed syslog )
+// Disabling RFC 5424 compliance is the default and needed due to https://github.com/heroku/logplex/issues/204
+func Encode(msg Message) ([]byte, error) {
+	sd := ""
+	if msg.RFCCompliant {
+		sd = "- "
+	}
+
+	if msg.Version == 0 {
+		return nil, errors.Wrap(ErrInvalidMessage, "version")
+	}
+
+	line := fmt.Sprintf("<%d>%d %s %s %s %s %s %s%s",
+		msg.Priority,
+		msg.Version,
+		msg.Timestamp.Format(SyslogTimeFormat),
+		stringOrNil(msg.Hostname),
+		stringOrNil(msg.Application),
+		stringOrNil(msg.Process),
+		stringOrNil(msg.ID),
+		sd,
+		msg.Message,
+	)
+
+	return []byte(strconv.Itoa(len(line)) + " " + line), nil
+}
+
+// MakeL15Error assembles an L15 error message
+func MakeL15Error() Message {
+	return Message{
+		// old log-tails says "l15Prival = []byte("<40>1")" - how to translate?
+		Priority:    1,
+		Hostname:    "host",
+		Application: "heroku",
+		Process:     "logplex",
+		Message:     L15Error,
+		Timestamp:   time.Now().UTC(),
+	}
+}
+
+func nilStringPointer(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func stringOrNil(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/logplex/encoding/encoder_test.go
+++ b/logplex/encoding/encoder_test.go
@@ -1,0 +1,151 @@
+package encoding
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"bytes"
+
+	"github.com/pkg/errors"
+)
+
+func TestEncode(t *testing.T) {
+	lockedDate, _ := time.Parse("2006-01-02T15:04:05.000Z", "2019-01-12T11:45:26.371Z")
+
+	tests := map[string]struct {
+		msg     Message
+		msgSize int64
+		err     error
+		writer  io.Writer
+	}{
+		"happy": {
+			msg: Message{
+				Version:     1,
+				Priority:    134,
+				Hostname:    "hostname",
+				Application: "application",
+				Process:     "process",
+				ID:          "msgid",
+				Timestamp:   lockedDate,
+				Message:     "hi",
+			},
+			writer:  ioutil.Discard,
+			msgSize: int64(77), // "74 <encoded msg>"
+		},
+
+		"missing-version": {
+			msg: Message{
+				Priority:    134,
+				Hostname:    "hostname",
+				Application: "application",
+				Process:     "process",
+				ID:          "msgid",
+				Timestamp:   lockedDate,
+				Message:     "hi",
+			},
+			writer: ioutil.Discard,
+			err:    ErrInvalidMessage,
+		},
+
+		"short-buffer": {
+			msg: Message{
+				Version:     1,
+				Priority:    134,
+				Hostname:    "hostname",
+				Application: "application",
+				Process:     "process",
+				ID:          "msgid",
+				Timestamp:   lockedDate,
+				Message:     "hi",
+			},
+			writer: failWrite{},
+			err:    io.EOF,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			n, err := test.msg.WriteTo(test.writer)
+			if got, want := errors.Cause(err), test.err; got != want {
+				t.Fatalf("expected %v, got %#v", want, got)
+			}
+
+			if n != test.msgSize {
+				t.Errorf("invalid encoded length\nexpected: %d, got %d", test.msgSize, n)
+			}
+		})
+	}
+}
+
+func TestEncoderTypes(t *testing.T) {
+	lockedDate, _ := time.Parse("2006-01-02T15:04:05.000Z", "2019-01-12T11:45:26.371Z")
+
+	tests := []struct {
+		name           string
+		encoderType    string
+		msg            Message
+		wantEncodedMsg string
+		wantErr        error
+	}{
+		{
+			name:        "successful encoding with plain encoder",
+			encoderType: "plain",
+			msg: Message{
+				Version:     1,
+				Priority:    134,
+				Hostname:    "hostname",
+				Application: "application",
+				Process:     "process",
+				ID:          "msgid",
+				Timestamp:   lockedDate,
+				Message:     "hi",
+			},
+			wantEncodedMsg: "2019-01-12T11:45:26.371+00:00 application[process]: hi",
+		},
+		{
+			name:        "successful encoding with SSE encoder",
+			encoderType: "sse",
+			msg: Message{
+				Version:     1,
+				Priority:    134,
+				Hostname:    "hostname",
+				Application: "application",
+				Process:     "process",
+				ID:          "msgid",
+				Timestamp:   lockedDate,
+				Message:     "hi",
+			},
+			wantEncodedMsg: "id: 1547293526\ndata: 2019-01-12T11:45:26.371+00:00 application[process]: hi\n\n\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			var e Encoder
+			if test.encoderType == "sse" {
+				e = NewSSE(w)
+			} else {
+				e = NewPlain(w)
+			}
+
+			err := e.Encode(test.msg)
+			if err != nil && test.wantErr != errors.Cause(err) {
+				t.Fatalf("want error: %v, got: %v", test.wantErr.Error(), errors.Cause(err))
+			}
+
+			// Verify message content even if an error is expected, received message should be empty
+			if test.wantEncodedMsg != w.String() {
+				t.Fatalf("want message: %v, got: %v", test.wantEncodedMsg, w.String())
+			}
+		})
+	}
+}
+
+type failWrite struct{}
+
+func (failWrite) Write([]byte) (int, error) {
+	return 0, io.EOF
+}

--- a/logplex/encoding/message.go
+++ b/logplex/encoding/message.go
@@ -1,0 +1,40 @@
+package encoding
+
+import (
+	"io"
+	"time"
+)
+
+// Message is a syslog message
+type Message struct {
+	Priority     uint8
+	Version      uint16
+	Timestamp    time.Time
+	Hostname     string
+	Application  string
+	Process      string
+	ID           string
+	Message      string
+	RFCCompliant bool
+}
+
+// Size returns the message size in bytes, including the octet framing header
+func (m Message) Size() (int, error) {
+	b, err := Encode(m)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(b), nil
+}
+
+// WriteTo writes the message to a stream
+func (m Message) WriteTo(w io.Writer) (int64, error) {
+	b, err := Encode(m)
+	if err != nil {
+		return 0, err
+	}
+
+	i, err := w.Write(b)
+	return int64(i), err
+}

--- a/logplex/encoding/message_test.go
+++ b/logplex/encoding/message_test.go
@@ -1,0 +1,52 @@
+package encoding
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TestMessageSize(t *testing.T) {
+	lockedDate, _ := time.Parse("2006-01-02T15:04:05.000Z", "2019-01-12T11:45:26.371Z")
+
+	tests := map[string]struct {
+		msg     Message
+		msgSize int
+		err     error
+	}{
+		"happy": {
+			msg: Message{
+				Version:     1,
+				Priority:    134,
+				Hostname:    "hostname",
+				Application: "application",
+				Process:     "process",
+				ID:          "msgid",
+				Timestamp:   lockedDate,
+				Message:     "hi",
+			},
+			msgSize: 77, // "74 <encoded msg>"
+		},
+
+		"invalid-msg": {
+			msg: Message{
+				Version: 0,
+			},
+			err: ErrInvalidMessage,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			size, err := test.msg.Size()
+			if errors.Cause(err) != test.err {
+				t.Errorf("expected %v, got %v", test.err, err)
+			}
+
+			if size != test.msgSize {
+				t.Errorf("expected %v, got %v", test.msgSize, size)
+			}
+		})
+	}
+}

--- a/logplex/encoding/scanner.go
+++ b/logplex/encoding/scanner.go
@@ -1,0 +1,162 @@
+package encoding
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/bmizerany/lpx"
+	syslog "github.com/influxdata/go-syslog"
+	"github.com/influxdata/go-syslog/octetcounting"
+	"github.com/pkg/errors"
+)
+
+// ErrBadFrame is returned when the scanner cannot parse syslog message boundaries
+var ErrBadFrame = errors.New("bad frame")
+
+// Decode converts a rfc5424 message to our model
+func Decode(res syslog.Message) Message {
+	return Message{
+		Priority:    *res.Priority(),
+		Version:     res.Version(),
+		Timestamp:   *res.Timestamp(),
+		Hostname:    nilStringPointer(res.Hostname()),
+		Application: nilStringPointer(res.Appname()),
+		Process:     nilStringPointer(res.ProcID()),
+		ID:          nilStringPointer(res.MsgID()),
+		Message:     nilStringPointer(res.Message()),
+	}
+}
+
+// syslogScanner is a octet-frame syslog parser
+type syslogScanner struct {
+	parser syslog.Parser
+	item   Message
+	err    error
+	more   chan *syslog.Result
+}
+
+// Scanner is the general purpose primitive for parsing message bodies coming
+// from log-shuttle, logfwd, logplex and all sorts of logging components.
+type Scanner interface {
+	Scan() bool
+	Err() error
+	Message() Message
+}
+
+// NewScanner is a syslog octet frame stream parser
+func NewScanner(r io.Reader) Scanner {
+	s := &syslogScanner{
+		more: make(chan *syslog.Result, 1),
+	}
+	s.parser = octetcounting.NewParser(syslog.WithListener(s.next))
+
+	go func() {
+		s.parser.Parse(r)
+		close(s.more)
+	}()
+
+	return s
+}
+
+func (s *syslogScanner) next(r *syslog.Result) {
+	s.more <- r
+}
+
+// Message returns the curent message
+func (s *syslogScanner) Message() Message {
+	return s.item
+}
+
+// Err returns the last scanner error
+func (s *syslogScanner) Err() error {
+	return s.err
+}
+
+// Scan returns true until all messages are parsed or an error occurs.
+// When an error occur, the underlying error will be presented as `Err()`
+func (s *syslogScanner) Scan() bool {
+	r, ok := <-s.more
+	if !ok {
+		return false
+	}
+
+	if r.Error != nil {
+		s.err = errors.Wrap(ErrBadFrame, r.Error.Error())
+		return false
+	}
+
+	s.item = Decode(r.Message)
+	return true
+}
+
+var privalVersionRe = regexp.MustCompile(`<(\d+)>(\d)+`)
+
+// NewDrainScanner returns a scanner for use with drain endpoints. The primary
+// difference is that it's lose and doesn't check for structured data.
+func NewDrainScanner(r io.ReadCloser) Scanner {
+	return &drainScanner{
+		lp: lpx.NewReader(bufio.NewReader(r)),
+	}
+}
+
+type drainScanner struct {
+	message Message
+	lp      *lpx.Reader
+	err     error
+}
+
+// Message returns the last parsed message.
+func (s *drainScanner) Message() Message {
+	return s.message
+}
+
+// Err returns the last known error.
+func (s *drainScanner) Err() error {
+	if s.err != nil {
+		return s.err
+	}
+	return s.lp.Err()
+}
+
+// Scan returns true when a message was parsed. It returns false otherwise.
+func (s *drainScanner) Scan() bool {
+	if !s.lp.Next() {
+		return false
+	}
+
+	hdr := s.lp.Header()
+	ts, err := time.Parse(SyslogTimeFormat, string(hdr.Time))
+	if err != nil {
+		s.err = err
+		return false
+	}
+
+	privalVersion := privalVersionRe.FindAllSubmatch(hdr.PrivalVersion, -1)
+
+	priority, err := strconv.Atoi(string(privalVersion[0][1]))
+	if err != nil {
+		s.err = err
+		return false
+	}
+
+	version, err := strconv.Atoi(string(privalVersion[0][2]))
+	if err != nil {
+		s.err = err
+		return false
+	}
+
+	s.message = Message{
+		Priority:    uint8(priority),
+		Version:     uint16(version),
+		ID:          string(hdr.Msgid),
+		Timestamp:   ts,
+		Hostname:    string(hdr.Hostname),
+		Application: string(hdr.Name),
+		Process:     string(hdr.Procid),
+		Message:     string(s.lp.Bytes()),
+	}
+	return true
+}

--- a/logplex/encoding/scanner_test.go
+++ b/logplex/encoding/scanner_test.go
@@ -1,0 +1,71 @@
+package encoding
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestScanner(t *testing.T) {
+	tests := map[string]struct {
+		log   string
+		count int
+		err   error
+	}{
+		"single": {
+			log:   "66 <190>1 2019-07-21T22:13:34.598992Z shuttle t.http shuttle - - 168\n",
+			count: 1,
+		},
+		"multiple": {
+			log:   "64 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 99\n65 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 100\n",
+			count: 2,
+		},
+
+		"short read": {
+			log:   "64 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 99\n10 ---",
+			count: 1,
+			err:   ErrBadFrame,
+		},
+
+		"bad frame size": {
+			log:   "64 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 99\n70 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 100",
+			count: 1,
+			err:   ErrBadFrame,
+		},
+
+		"bad frame position": {
+			log:   "64 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 99\n 65 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 100",
+			count: 1,
+			err:   ErrBadFrame,
+		},
+
+		"bad frame format": {
+			log:   "xxxxxxxxxxxxxxxx",
+			count: 0,
+			err:   ErrBadFrame,
+		},
+	}
+
+	isCause := func(cause error, err error) bool {
+		return !(errors.Cause(err) == cause)
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			scanner := NewScanner(strings.NewReader(test.log))
+			i := 0
+			for scanner.Scan() {
+				i++
+			}
+			if got, want := i, test.count; got != want {
+				t.Errorf("expected %v, got %v", want, got)
+			}
+
+			if got, want := scanner.Err(), test.err; isCause(test.err, scanner.Err()) {
+				t.Errorf("scanner: expected %v, got %v", want, got)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
A logplex compatible encoder & decoder.

This currently has 2 main uses:

1. For taking a more strict ingress, e.g. octetcounting.
2. For taking a more liberal ingress, e.g. syslog without structured data.
