### PR TITLE
add basic auth package

### DIFF
--- a/hmiddleware/basicauth/checker.go
+++ b/hmiddleware/basicauth/checker.go
@@ -1,0 +1,70 @@
+package basicauth
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Credentials is a set of credentials with the added functionality of
+// decoding.
+type Credentials []Credential
+
+// Decode implements the envdecode contract, allowing Credentials to be used in
+// config structs.
+func (c *Credentials) Decode(repl string) error {
+	var result []Credential
+	for _, part := range strings.Split(repl, ";") {
+		cred, err := parseCredential(part)
+		if err != nil {
+			return err
+		}
+		result = append(result, cred)
+	}
+
+	*c = result
+	return nil
+}
+
+// Credential is a valid username/password pair used to authenticate HTTP
+// requests using basic auth.
+type Credential struct {
+	Username string
+	Password string
+}
+
+var errMalformedCredentials = errors.New("malformed credentials")
+
+func parseCredential(credential string) (Credential, error) {
+	parts := strings.SplitN(credential, ":", 2)
+	if len(parts) != 2 {
+		return Credential{}, errMalformedCredentials
+	} else if parts[0] == "" && parts[1] == "" {
+		return Credential{}, errMalformedCredentials
+	}
+	return Credential{Username: parts[0], Password: parts[1]}, nil
+}
+
+// Checker stores a set of valid credentials to be used when authenticating
+// HTTP requests using basic auth.
+type Checker struct {
+	credentials []Credential
+}
+
+// NewChecker returns a basic auth checker configured to use credentials
+// when checking for valid authentication.
+func NewChecker(credentials []Credential) *Checker {
+	return &Checker{
+		credentials: credentials,
+	}
+}
+
+// Valid is true if username and password represent acceptable credentials.
+func (c *Checker) Valid(username, password string) bool {
+	for _, cred := range c.credentials {
+		if cred.Username == username && cred.Password == password {
+			return true
+		}
+	}
+	return false
+}

--- a/hmiddleware/basicauth/checker_test.go
+++ b/hmiddleware/basicauth/checker_test.go
@@ -1,0 +1,151 @@
+package basicauth
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/joeshaw/envdecode"
+)
+
+func TestCredentialsWithEnvDecode(t *testing.T) {
+	os.Setenv("TEST_VALID_CREDS", "user:pass;user2:pass2")
+	defer func() {
+		os.Setenv("TEST_VALID_CREDS", "")
+	}()
+
+	var cfg struct {
+		ValidCreds Credentials `env:"TEST_VALID_CREDS,required"`
+	}
+
+	if err := envdecode.StrictDecode(&cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	want := Credentials{{"user", "pass"}, {"user2", "pass2"}}
+
+	if !reflect.DeepEqual(want, cfg.ValidCreds) {
+		t.Fatalf("want: %+v, got %+v", want, cfg.ValidCreds)
+	}
+
+	// Ensure that we can pass this in to NewChecker all the time, since
+	// this is the main.go UX we're going for.
+	_ = NewChecker(cfg.ValidCreds)
+}
+
+func TestCredentials(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *Credentials
+		wantErr error
+	}{
+		{
+			name:  "one credential",
+			input: "user:pass",
+			want:  &Credentials{{"user", "pass"}},
+		},
+		{
+			name:  "two credentials",
+			input: "user:pass;user2:pass2",
+			want:  &Credentials{{"user", "pass"}, {"user2", "pass2"}},
+		},
+		{
+			name:    "bad format",
+			input:   "user",
+			want:    &Credentials{},
+			wantErr: errMalformedCredentials,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := &Credentials{}
+			gotErr := got.Decode(test.input)
+
+			if !reflect.DeepEqual(test.wantErr, gotErr) {
+				t.Fatalf("want err: %v, got %v", test.wantErr, gotErr)
+			}
+
+			if !reflect.DeepEqual(test.want, got) {
+				t.Fatalf("wanted credentials: %+v, got %+v", test.want, got)
+			}
+		})
+	}
+}
+
+func TestChecker(t *testing.T) {
+	checker := NewChecker([]Credential{
+		{Username: "username", Password: "password"},
+		{Username: "different", Password: ""},
+		{Username: "", Password: "secret"},
+	})
+	cases := []struct {
+		username, password string
+		want               bool
+	}{
+		{"username", "password", true},
+		{"invalid", "password", false},
+		{"username", "invalid", false},
+		{"different", "", true},
+		{"", "secret", true},
+		{"", "", false},                 // username and password required
+		{"different", "invalid", false}, // password match required
+		{"invalid", "secret", false},    // username match required
+		{"", "password", false},         // username match required
+	}
+	for i, tt := range cases {
+		if got := checker.Valid(tt.username, tt.password); got != tt.want {
+			t.Errorf("%d. got %v, want %v", i+1, got, tt.want)
+		}
+	}
+}
+
+// parseCredential returns a Credential instance built from the username and
+// password in the provided colon-separated string.
+func TestParseCredential(t *testing.T) {
+	cred, err := parseCredential("username:password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cred.Username != "username" && cred.Password != "password" {
+		t.Fatalf("got %s:%s but want username:password", cred.Username, cred.Password)
+	}
+}
+
+// parseCredential allows the password to be blank.
+func TestParseCredentialWithMissingPassword(t *testing.T) {
+	cred, err := parseCredential("username:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cred.Username != "username" && cred.Password != "" {
+		t.Fatalf("got `%s:%s` but want `username:`", cred.Username, cred.Password)
+	}
+}
+
+// parseCredential allows the username to be blank.
+func TestParseCredentialWithMissingUsername(t *testing.T) {
+	cred, err := parseCredential(":secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cred.Username != "" && cred.Password != "secret" {
+		t.Fatalf("got `%s:%s` but want `:secret`", cred.Username, cred.Password)
+	}
+}
+
+// parseCredential requires the username or password to be present.
+func TestParseCredentialWithMissingValues(t *testing.T) {
+	if _, err := parseCredential(":"); err == nil {
+		t.Fatal("got nil but want error")
+	}
+}
+
+// parseCredential returns an error if the specified credentials don't contain
+// both a usernamer and password.
+func TestParseCredentialWithMalformedCredentials(t *testing.T) {
+	if _, err := parseCredential("malformed"); err == nil {
+		t.Fatal("got nil but want error")
+	}
+}

--- a/hmiddleware/basicauth/grpc.go
+++ b/hmiddleware/basicauth/grpc.go
@@ -1,0 +1,105 @@
+package basicauth
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+)
+
+// scheme is the Authorization prefix in the header, e.g. `Basic <base 64 blob>`.
+const scheme = "basic"
+
+// GRPCAuthFunc creates grpc_auth.AuthFunc. It does authentication using the
+// basic auth scheme, and validates any user/password sent using checker.
+func GRPCAuthFunc(checker *Checker) func(ctx context.Context) (context.Context, error) {
+	return func(ctx context.Context) (context.Context, error) {
+		blob, err := grpc_auth.AuthFromMD(ctx, scheme)
+		if err != nil {
+			return nil, err
+		}
+
+		user, pass, ok := parseBasicAuth(blob)
+		if !ok {
+			return nil, grpc.Errorf(codes.Unauthenticated, "unauthenticated")
+		}
+
+		if !checker.Valid(user, pass) {
+			return nil, grpc.Errorf(codes.PermissionDenied, "permission denied")
+		}
+
+		return ctx, nil
+	}
+}
+
+var _ credentials.PerRPCCredentials = &GRPCCredentials{}
+
+// GRPCCredentials implements PerRPCCredentials.
+type GRPCCredentials struct {
+	Username, Password string
+
+	TransportSecurity bool
+}
+
+// GetRequestMetadata maps the given credentials to the appropriate request
+// headers.
+func (c GRPCCredentials) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
+	return map[string]string{
+		"authorization": basicAuth(c.Username, c.Password),
+	}, nil
+}
+
+// RequireTransportSecurity implements PerRPCCredentials.
+func (c GRPCCredentials) RequireTransportSecurity() bool {
+	return c.TransportSecurity
+}
+
+var errForbidden = grpc.Errorf(codes.Unauthenticated, "Forbidden")
+
+func authorize(ctx context.Context, checker *Checker) error {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return errForbidden
+	}
+
+	auth := md.Get("authorization")
+	if len(auth) != 1 {
+		return errForbidden
+	}
+
+	user, pass, ok := parseBasicAuth(auth[0])
+	if !ok {
+		return errForbidden
+	}
+
+	if !checker.Valid(user, pass) {
+		return errForbidden
+	}
+
+	return nil
+}
+
+func parseBasicAuth(auth string) (user, pass string, ok bool) {
+	c, err := base64.StdEncoding.DecodeString(auth)
+	if err != nil {
+		return
+	}
+
+	cs := string(c)
+	s := strings.IndexByte(cs, ':')
+	if s < 0 {
+		return
+	}
+
+	user, pass, ok = cs[:s], cs[s+1:], true
+	return
+}
+
+func basicAuth(user, pass string) string {
+	return scheme + " " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+}

--- a/hmiddleware/basicauth/grpc_test.go
+++ b/hmiddleware/basicauth/grpc_test.go
@@ -1,0 +1,74 @@
+package basicauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	"github.com/heroku/x/grpc/grpcclient"
+	"github.com/heroku/x/grpc/grpcserver"
+	"github.com/heroku/x/testing/testlog"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/examples/route_guide/routeguide"
+)
+
+func TestGRPCPerRPCCredentialBasicAuth(t *testing.T) {
+	l, _ := testlog.NewNullLogger()
+	mux := http.NewServeMux()
+
+	checker := NewChecker([]Credential{{"user", "pass"}})
+
+	gSrv, hSrv := grpcserver.NewStandardH2C(
+		mux,
+		grpcserver.AuthInterceptors(
+			grpc_auth.UnaryServerInterceptor(GRPCAuthFunc(checker)),
+			grpc_auth.StreamServerInterceptor(GRPCAuthFunc(checker)),
+		),
+		grpcserver.LogEntry(l.WithField("at", "grpc")),
+	)
+
+	routeguide.RegisterRouteGuideServer(gSrv, &fakeServer{})
+
+	srv := httptest.NewServer(hSrv.Handler)
+	defer srv.Close()
+
+	conn, err := grpcclient.DialH2C(
+		srv.URL,
+		grpc.WithTimeout(10*time.Second),
+		grpc.WithBlock(),
+		grpc.WithWaitForHandshake(),
+		grpc.WithPerRPCCredentials(&GRPCCredentials{Username: "user", Password: "pass"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := routeguide.NewRouteGuideClient(conn)
+	_, err = client.GetFeature(context.Background(), &routeguide.Point{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type fakeServer struct {
+}
+
+func (s *fakeServer) GetFeature(context.Context, *routeguide.Point) (*routeguide.Feature, error) {
+	return &routeguide.Feature{}, nil
+}
+
+func (s *fakeServer) ListFeatures(*routeguide.Rectangle, routeguide.RouteGuide_ListFeaturesServer) error {
+	return errors.New("unimplemented")
+}
+
+func (s *fakeServer) RecordRoute(routeguide.RouteGuide_RecordRouteServer) error {
+	return errors.New("unimplemented")
+}
+
+func (s *fakeServer) RouteChat(routeguide.RouteGuide_RouteChatServer) error {
+	return errors.New("unimplemented")
+}

--- a/hmiddleware/basicauth/handler.go
+++ b/hmiddleware/basicauth/handler.go
@@ -1,0 +1,25 @@
+package basicauth
+
+import (
+	"net/http"
+
+	"github.com/heroku/x/go-kit/metrics"
+)
+
+// Authenticate creates a middleware style HTTP handler that enforces valid
+// basic auth credentials before allowing a request to continue to handler.
+func (c *Checker) Authenticate(metricsProvider metrics.Provider) func(handler http.Handler) http.Handler {
+	counter := metricsProvider.NewCounter("server.request-auth-failures")
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			username, password, ok := r.BasicAuth()
+			if !ok || !c.Valid(username, password) {
+				w.WriteHeader(http.StatusForbidden)
+				counter.Add(1)
+				return
+			}
+			h.ServeHTTP(w, r)
+		})
+	}
+}

--- a/hmiddleware/basicauth/handler_test.go
+++ b/hmiddleware/basicauth/handler_test.go
@@ -1,0 +1,93 @@
+package basicauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/heroku/x/go-kit/metrics/testmetrics"
+)
+
+// Authenticate returns a handler that passes a request to the underlying
+// handler if basic auth credentials are valid.
+func TestAuthenticate(t *testing.T) {
+	metricsProvider := testmetrics.NewProvider(t)
+	checker := NewChecker([]Credential{
+		{Username: "username", Password: "password"},
+	})
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	s := httptest.NewServer(checker.Authenticate(metricsProvider)(h))
+	uri, _ := url.Parse(s.URL)
+	uri.User = url.UserPassword("username", "password")
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", s.URL, nil)
+	req.SetBasicAuth("username", "password")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d but want %d", resp.StatusCode, http.StatusOK)
+	}
+	metricsProvider.CheckCounter("server.request-auth-failures", 0)
+}
+
+// Authenticate returns a handler that returns an HTTP 403 Forbidden and
+// doesn't allow the request to passthrough to the underlying handler if
+// an unknown username is provided.
+func TestAuthenticateWithUnknownUsername(t *testing.T) {
+	metricsProvider := testmetrics.NewProvider(t)
+	checker := NewChecker([]Credential{
+		{Username: "username", Password: "password"},
+	})
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	s := httptest.NewServer(checker.Authenticate(metricsProvider)(h))
+	uri, _ := url.Parse(s.URL)
+	uri.User = url.UserPassword("username", "password")
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", s.URL, nil)
+	req.SetBasicAuth("invalid", "password")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("got %d but want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	metricsProvider.CheckCounter("server.request-auth-failures", 1)
+}
+
+// Authenticate returns a handler that returns an HTTP 403 Forbidden and
+// doesn't allow the request to passthrough to the underlying handler if an
+// invalid password is provided.
+func TestAuthenticateWithInvalidPassword(t *testing.T) {
+	metricsProvider := testmetrics.NewProvider(t)
+	checker := NewChecker([]Credential{
+		{Username: "username", Password: "password"},
+	})
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	s := httptest.NewServer(checker.Authenticate(metricsProvider)(h))
+	uri, _ := url.Parse(s.URL)
+	uri.User = url.UserPassword("username", "password")
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", s.URL, nil)
+	req.SetBasicAuth("username", "invalid")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("got %d but want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	metricsProvider.CheckCounter("server.request-auth-failures", 1)
+}


### PR DESCRIPTION
## Context

The basic auth package allows us to utilize a simple in memory
authentication mechanism which can be used both for HTTP and gRPC
servers.