### PR TITLE
hmiddleware: add acm

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
@@ -112,6 +113,7 @@ golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190502183928-7f726cade0ab h1:9RfW3ktsOZxgo9YNbBAjq1FWzc/igwEcUzZz8IXgSbk=
 golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -132,6 +134,7 @@ gonum.org/v1/gonum v0.0.0-20190502212712-4a2eb0188cbc h1:+c7TChc7Bi9WFPyWzDxu8mn
 gonum.org/v1/gonum v0.0.0-20190502212712-4a2eb0188cbc/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
+google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20181221175505-bd9b4fb69e2f h1:eT3B0O2ghdSPzjAOznr3oOLyN1HFeYUncYl7FRwg4VI=

--- a/hmiddleware/acm.go
+++ b/hmiddleware/acm.go
@@ -1,0 +1,31 @@
+package hmiddleware
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const http01ChallengePath = "/.well-known/acme-challenge/"
+
+// ACMEValidationMiddleware implements the HTTP01 based redirect protocol
+// specific to heroku ACM.
+func ACMEValidationMiddleware(validationURL *url.URL) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, http01ChallengePath) {
+				qs := validationURL.Query()
+				qs.Set("token", strings.TrimPrefix(r.URL.Path, http01ChallengePath))
+				qs.Set("host", r.Host)
+
+				u := *validationURL
+				u.RawQuery = qs.Encode()
+
+				http.Redirect(w, r, u.String(), http.StatusMovedPermanently)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/hmiddleware/acm_test.go
+++ b/hmiddleware/acm_test.go
@@ -1,0 +1,85 @@
+package hmiddleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestACMEValidationMiddleware(t *testing.T) {
+	app := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	validationURL := &url.URL{Scheme: "https", Host: "acm.local", Path: "/challenge", RawQuery: "foo=bar"}
+
+	server := httptest.NewServer(ACMEValidationMiddleware(validationURL)(app))
+	defer server.Close()
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantQuery := url.Values{
+		"foo":   []string{"bar"},
+		"token": []string{"some-token"},
+		"host":  []string{serverURL.Host},
+	}
+
+	tests := []struct {
+		name string
+		url  string
+
+		wantStatus int
+		wantURL    *url.URL
+	}{
+		{
+			name:       "no challenge path",
+			url:        server.URL,
+			wantStatus: http.StatusOK,
+		},
+
+		{
+			name:       "with challenge path",
+			url:        server.URL + http01ChallengePath + "some-token",
+			wantStatus: http.StatusMovedPermanently,
+			wantURL:    validationURL.ResolveReference(&url.URL{RawQuery: wantQuery.Encode()}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp, err := client.Get(test.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.wantStatus != resp.StatusCode {
+				t.Fatalf("want code: %d got %d", test.wantStatus, resp.StatusCode)
+			}
+
+			if test.wantURL != nil {
+				gotURL, err := resp.Location()
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if want, got := test.wantURL.String(), gotURL.String(); want != got {
+					t.Fatalf("want location redirect: %s, got %s", want, got)
+				}
+			}
+
+			if validationURL.RawQuery != "foo=bar" {
+				t.Fatalf("want raw query to still be `foo=bar`, got %q", validationURL.RawQuery)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This middleware is useful for implementing the heroku ACM specific
contract for redirecting to the origin ACM servers.

Customers shouldn't need to use this if they're just leveraging the
platform normally -- but is more for fringe cases.