### PR TITLE
add tickgroup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20190502183928-7f726cade0ab // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 	gonum.org/v1/gonum v0.0.0-20190502212712-4a2eb0188cbc // indirect
 	google.golang.org/grpc v1.20.1
 	gopkg.in/caio/go-tdigest.v2 v2.3.0

--- a/tickgroup/tickgroup.go
+++ b/tickgroup/tickgroup.go
@@ -1,0 +1,57 @@
+package tickgroup
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// A Group is a collection of goroutines working on subtask that are spawned on
+// a set interval per task.
+type Group struct {
+	g     *errgroup.Group
+	donec <-chan struct{}
+}
+
+// New returns a new Group that stops spawning subtasks when ctx is done.
+func New(ctx context.Context) *Group {
+	return &Group{g: new(errgroup.Group), donec: ctx.Done()}
+}
+
+// WithContext creates a child context from the given context, and uses that to
+// control context cancelation.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	g, ctx := errgroup.WithContext(ctx)
+	return &Group{g: g, donec: ctx.Done()}, ctx
+}
+
+// Go spawns a subtask f every d. The goroutine terminates when an error is
+// encountered. The first call to return a non-nil error cancels the group; its
+// error will be returned by Wait.
+func (g *Group) Go(d time.Duration, f func() error) {
+	g.g.Go(func() error {
+		if err := f(); err != nil {
+			return err
+		}
+
+		t := time.NewTicker(d)
+		defer t.Stop()
+
+		for {
+			select {
+			case <-g.donec:
+				return nil
+
+			case <-t.C:
+				if err := f(); err != nil {
+					return err
+				}
+			}
+		}
+	})
+}
+
+// Wait blocks until all function calls from the Go method have returned,
+// then returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error { return g.g.Wait() }

--- a/tickgroup/tickgroup_test.go
+++ b/tickgroup/tickgroup_test.go
@@ -1,0 +1,80 @@
+package tickgroup
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGroup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	group := New(ctx)
+
+	var ticks uint32
+	group.Go(5*time.Millisecond, func() error {
+		if atomic.AddUint32(&ticks, 1) == 5 {
+			cancel()
+			return nil
+		}
+		return nil
+	})
+
+	if err := group.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	if want, got := 5, int(atomic.LoadUint32(&ticks)); want != got {
+		t.Fatalf("want tick count %d, got %d", want, got)
+	}
+}
+
+func TestGroupWithContext(t *testing.T) {
+	group, ctx := WithContext(context.Background())
+
+	wantErr := errors.New("done")
+
+	var ticks uint32
+	group.Go(5*time.Millisecond, func() error {
+		if atomic.AddUint32(&ticks, 1) == 5 {
+			return wantErr
+		}
+		return nil
+	})
+
+	if gotErr := group.Wait(); gotErr != wantErr {
+		t.Fatalf("want err: %v, got err %v", wantErr, gotErr)
+	}
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("wanted ctx to have been canceled")
+	}
+
+	if want, got := 5, int(atomic.LoadUint32(&ticks)); want != got {
+		t.Fatalf("want tick count %d, got %d", want, got)
+	}
+}
+
+func TestGroupRunsImmediatelyBeforeWaiting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	group := New(ctx)
+
+	var ticks uint32
+	group.Go(time.Hour, func() error {
+		if atomic.AddUint32(&ticks, 1) == 1 {
+			cancel()
+		}
+		return nil
+	})
+
+	if err := group.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	if want, got := 1, int(atomic.LoadUint32(&ticks)); want != got {
+		t.Fatalf("want tick count %d, got %d", want, got)
+	}
+}


### PR DESCRIPTION
## Context

Tickgroup is useful in cases where you want a clock process that takes
action every N seconds.

In certain cases, you'd want them ticking at different rates, or even
have multiple tickgroups orchestrated on a higher level.