### PR TITLE
tickgroup: move docs to godoc

### DIFF
--- a/tickgroup/README.md
+++ b/tickgroup/README.md
@@ -1,34 +1,8 @@
 # tickgroup
 
-## Overview
+A tickgroup is a collection of goroutines that are spawned to call a subtask
+every set interval.
 
-A tickgroup is a collection of goroutines that are spawned to call `f()`
-every set interval.  A  tickgroup will stop spawning subtasks, when `ctx` is
-done.  If subtask `f()` encounters an error, the tickgroup is canceled and
-the error is returned.
+## Documentation
 
-## Example
-
-This example uses the tickgroup package to create a simple 5 second timer.  A
-tickgroup `tg` with a cancel context is initialized.  Inside of `Go()`, `i`
-is incremented every 1 second; after 5 seconds the context is canceled and
-`Wait()` returns a nil value, which ceases the process.
-
-```go
-ctx, cancel := context.WithCancel(context.Background())
-tg := tickgroup.New(ctx)
-
-var i int
-tg.Go(time.Second, func() error {
-	if i > 4 {
-		cancel()
-		return nil
-	}
-	i++
-	return nil
-})
-
-if err := tg.Wait(); err != nil {
-	log.Print(err)
-}
-```
+Full documentation is available on [godoc](https://godoc.org/github.com/heroku/x/tickgroup).

--- a/tickgroup/example_test.go
+++ b/tickgroup/example_test.go
@@ -1,0 +1,41 @@
+package tickgroup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/heroku/runtime/lib/tickgroup"
+)
+
+// This example uses the tickgroup package to create a simple 5 second timer.
+func Example() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// A tickgroup tg with a cancel context is initialized.
+	tg := tickgroup.New(ctx)
+
+	var i int
+	tg.Go(time.Second, func() error {
+		if i > 4 {
+			cancel()
+			return nil
+		}
+		// i is incremeneted every 1 second.
+		i++
+		fmt.Println(i)
+		return nil
+	})
+
+	// After 5 seconds the context is canceled and Wait() returns a nil value, which ceases the process.
+	if err := tg.Wait(); err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// 1
+	// 2
+	// 3
+	// 4
+	// 5
+}

--- a/tickgroup/example_test.go
+++ b/tickgroup/example_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	"github.com/heroku/runtime/lib/tickgroup"
 )
 
 // This example uses the tickgroup package to create a simple 5 second timer.
@@ -13,7 +11,7 @@ func Example() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// A tickgroup tg with a cancel context is initialized.
-	tg := tickgroup.New(ctx)
+	tg := New(ctx)
 
 	var i int
 	tg.Go(time.Second, func() error {

--- a/tickgroup/tickgroup.go
+++ b/tickgroup/tickgroup.go
@@ -1,3 +1,4 @@
+// Package tickgroup allows a collection of goroutines to call a subtask every set time interval.
 package tickgroup
 
 import (


### PR DESCRIPTION
Per feedback in #85, moving documentation for `tickgroup` to godoc.