### PR TITLE
Add example for httpmetrics

### DIFF
--- a/go-kit/metrics/testmetrics/provider.go
+++ b/go-kit/metrics/testmetrics/provider.go
@@ -1,3 +1,5 @@
+// Package testmetrics is for testing provider metrics
+// with a test Provider that adheres to the Provider interface
 package testmetrics
 
 import (

--- a/go-kit/metrics/testmetrics/provider.go
+++ b/go-kit/metrics/testmetrics/provider.go
@@ -1,6 +1,7 @@
 package testmetrics
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -125,6 +126,16 @@ func (p *Provider) CheckCounter(name string, v float64, labelValues ...string) {
 	if len(labelValues) > 0 && !reflect.DeepEqual(labelValues, c.labelValues) {
 		p.t.Fatalf("want counter label values: %#v, got %#v", labelValues, c.labelValues)
 	}
+}
+
+// PrintCounterValue prints the value of the specified counter and their current counts
+func (p *Provider) PrintCounterValue(name string) {
+	p.t.Helper()
+
+	p.Lock()
+	defer p.Unlock()
+
+	fmt.Printf("%s: %v\n", name, p.counters[name].getValue())
 }
 
 // CheckNoCounter checks that there is no registered counter with the name

--- a/hmiddleware/httpmetrics/httpmetrics_test.go
+++ b/hmiddleware/httpmetrics/httpmetrics_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/heroku/x/go-kit/metrics/testmetrics"
 )
 
-// This example shows how http metrics will be collected for requests
+// This example demonstrates how to set up metrics and what will be collected on requests
 func Example() {
 	// Create a new Metrics Provider
 	provider := testmetrics.NewProvider(&testing.T{})

--- a/hmiddleware/httpmetrics/httpmetrics_test.go
+++ b/hmiddleware/httpmetrics/httpmetrics_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // This example shows how http metrics will be collected for requests
-func Example(){
+func Example() {
 	// Create a new Metrics Provider
 	provider := testmetrics.NewProvider(&testing.T{})
 	r := chi.NewRouter()
@@ -26,13 +26,13 @@ func Example(){
 
 	// Metrics will be collected around http OK statuses
 	// For all requests and for /foo requests
-	r.Get("/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){
+	r.Get("/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	// Metrics will be collected around http Bad Request statuses
 	// For all requests and for /bar requests
-	r.Get("/bar", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){
+	r.Get("/bar", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
 
@@ -40,11 +40,15 @@ func Example(){
 	defer server.Close()
 
 	// Metrics will be collected for each request
-	req, _ := http.NewRequest("GET", server.URL + "/foo", nil)
-	http.DefaultClient.Do(req)
+	req, _ := http.NewRequest("GET", server.URL+"/foo", nil)
+	if _, err := http.DefaultClient.Do(req); err != nil {
+		fmt.Println(err)
+	}
 
-	req, _ = http.NewRequest("GET", server.URL + "/bar", nil)
-	http.DefaultClient.Do(req)
+	req, _ = http.NewRequest("GET", server.URL+"/bar", nil)
+	if _, err := http.DefaultClient.Do(req); err != nil {
+		fmt.Println(err)
+	}
 
 	provider.PrintCounterValue("http.server.get.bar.response-statuses.400")
 	provider.PrintCounterValue("http.server.all.requests")

--- a/hmiddleware/httpmetrics/httpmetrics_test.go
+++ b/hmiddleware/httpmetrics/httpmetrics_test.go
@@ -13,6 +13,57 @@ import (
 	"github.com/heroku/x/go-kit/metrics/testmetrics"
 )
 
+// This example shows how http metrics will be collected for requests
+func Example(){
+	// Create a new Metrics Provider
+	provider := testmetrics.NewProvider(&testing.T{})
+	r := chi.NewRouter()
+
+	// Use the Metrics Provider to create a new HTTP Handler
+	r.Use(func(next http.Handler) http.Handler {
+		return NewServer(provider, next)
+	})
+
+	// Metrics will be collected around http OK statuses
+	// For all requests and for /foo requests
+	r.Get("/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Metrics will be collected around http Bad Request statuses
+	// For all requests and for /bar requests
+	r.Get("/bar", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	server := httptest.NewServer(r)
+	defer server.Close()
+
+	// Metrics will be collected for each request
+	req, _ := http.NewRequest("GET", server.URL + "/foo", nil)
+	http.DefaultClient.Do(req)
+
+	req, _ = http.NewRequest("GET", server.URL + "/bar", nil)
+	http.DefaultClient.Do(req)
+
+	provider.PrintCounterValue("http.server.get.bar.response-statuses.400")
+	provider.PrintCounterValue("http.server.all.requests")
+	provider.PrintCounterValue("http.server.all.response-statuses.200")
+	provider.PrintCounterValue("http.server.get.foo.requests")
+	provider.PrintCounterValue("http.server.get.foo.response-statuses.200")
+	provider.PrintCounterValue("http.server.all.response-statuses.400")
+	provider.PrintCounterValue("http.server.get.bar.requests")
+
+	// Output:
+	// http.server.get.bar.response-statuses.400: 1
+	// http.server.all.requests: 2
+	// http.server.all.response-statuses.200: 1
+	// http.server.get.foo.requests: 1
+	// http.server.get.foo.response-statuses.200: 1
+	// http.server.all.response-statuses.400: 1
+	// http.server.get.bar.requests: 1
+}
+
 func TestServer(t *testing.T) {
 	p := testmetrics.NewProvider(t)
 


### PR DESCRIPTION
This adds an example for the godocs of `httpmetrics`. 