### PR TITLE
logplex/encoding: Adding fallback time format

### DIFF
--- a/logplex/encoding/encoder.go
+++ b/logplex/encoding/encoder.go
@@ -8,11 +8,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-// SyslogTimeFormat defines the exact time format used in our logs.
+// SyslogTimeFormat defines the exact time format used in our egress logs.
 const SyslogTimeFormat = "2006-01-02T15:04:05.999999-07:00"
 
-// FlexibleSyslogTimeFormat accepts both 'Z' and TZ notation for event time.
+// FlexibleSyslogTimeFormat accepts both 'Z' and TZ notation for ingress event time.
 const FlexibleSyslogTimeFormat = "2006-01-02T15:04:05.999999Z07:00"
+
+// FallbackSyslogTimeFormat is a fallback for ingress event time.
+// It assumes UTC as timezone
+const FallbackSyslogTimeFormat = "2006-01-02T15:04:05"
 
 // L15Error is the message returned with an L15 error
 const L15Error = "L15: Error displaying log lines. Please try again."

--- a/logplex/encoding/scanner.go
+++ b/logplex/encoding/scanner.go
@@ -55,7 +55,14 @@ func Decode(raw []byte, hasStructuredData bool) (Message, error) {
 	}
 	msg.Timestamp, err = time.Parse(FlexibleSyslogTimeFormat, string(rawTime))
 	if err != nil {
-		return msg, err
+		if _, ok := err.(*time.ParseError); !ok {
+			return msg, err
+		}
+
+		msg.Timestamp, err = time.Parse(FallbackSyslogTimeFormat, string(rawTime))
+		if err != nil {
+			return msg, err
+		}
 	}
 
 	hostname, err := syslogField(b)

--- a/logplex/encoding/scanner_test.go
+++ b/logplex/encoding/scanner_test.go
@@ -37,6 +37,13 @@ func TestScanner(t *testing.T) {
 			wantPriority: 190,
 		},
 
+		"fallback timeformat": {
+			log:          "58 <190>1 2019-07-21T22:13:34 shuttle t.http shuttle - - 168\n",
+			count:        1,
+			wantVersion:  1,
+			wantPriority: 190,
+		},
+
 		"bad frame size": {
 			log:          "64 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 99\n70 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 100",
 			count:        1,


### PR DESCRIPTION
Some of our clients are not sending a timezone neither `Z` as part of the their timestamps.
This used to be accepted by Logplex, so we are adding it back as fallback.