### PR TITLE
redispool: Add optional config to set max conn lifetime

### DIFF
--- a/cmdutil/redispool/redispool.go
+++ b/cmdutil/redispool/redispool.go
@@ -1,3 +1,5 @@
+// Package redispool supports setting up redis connection pools parameterized
+// via environment variables.
 package redispool
 
 import (
@@ -10,13 +12,38 @@ import (
 
 // Config stores all the basic redis pool configuration knobs.
 type Config struct {
-	URL               string        `env:"REDIS_URL,default=redis://127.0.0.1:6379"`
-	MaxIdleConns      int           `env:"REDIS_MAX_IDLE_CONNS,default=1"`
-	MaxActiveConns    int           `env:"REDIS_MAX_ACTIVE_CONNS,default=50"`
-	MaxConnLifetime   time.Duration `env:"REDIS_MAX_CONN_LIFETIME,default=0s"`
-	IdleTimeout       time.Duration `env:"REDIS_IDLE_TIMEOUT,default=0s"`
+	// URL is the redis URL the pool connects to, configured via `REDIS_URL`.
+	URL string `env:"REDIS_URL,default=redis://127.0.0.1:6379"`
+
+	// MaxIdleConns is the maximum number of idle connections in a pool,
+	// configured via `REDIS_MAX_IDLE_CONNS`, defaults to 1.
+	MaxIdleConns int `env:"REDIS_MAX_IDLE_CONNS,default=1"`
+
+	// MaxActiveConns is the maximum number of active connections in a pool,
+	// configured via `REDIS_MAX_ACTIVE_CONNS`, defaults to 50.
+	MaxActiveConns int `env:"REDIS_MAX_ACTIVE_CONNS,default=50"`
+
+	// MaxConnLifetime is the maximum lifetime of any connection in a pool,
+	// configured via `REDIS_MAX_CONN_LIFETIME`, defaults to 0s.
+	// Connections older than this duration will be closed. If the value is zero,
+	// then the pool does not close connections based on age.
+	MaxConnLifetime time.Duration `env:"REDIS_MAX_CONN_LIFETIME,default=0s"`
+
+	// IdleTimeout is the duration how long connections can be idle before they're
+	// closed, configured via `REDIS_IDLE_TIMEOUT`. When set to zero idle
+	// connections won't be closed. Defaults to 0s.
+	IdleTimeout time.Duration `env:"REDIS_IDLE_TIMEOUT,default=0s"`
+
+	// IdleProbeInterval is the duration between the aliveness checks of idle
+	// connections, configured via `REDIS_IDLE_PROBE_INTERVAL` which defaults to 0.
+	// When set to zero, aliveness is not checked.
 	IdleProbeInterval time.Duration `env:"REDIS_IDLE_PROBE_INTERVAL,default=0s"`
-	AttachmentNames   []string      `env:"REDIS_ATTACHMENT_NAMES"`
+
+	// AttachmentNames is an optional configuration which allows to set up
+	// connection pools to each redis attachment using the Pools() function. The
+	// same configuration parameters apply for each pool, except the URL which is
+	// extracted from the environment based on the attachment name.
+	AttachmentNames []string `env:"REDIS_ATTACHMENT_NAMES"`
 }
 
 // Pool returns a *redis.Pool given the configured env vars in Config.

--- a/cmdutil/redispool/redispool.go
+++ b/cmdutil/redispool/redispool.go
@@ -13,6 +13,7 @@ type Config struct {
 	URL               string        `env:"REDIS_URL,default=redis://127.0.0.1:6379"`
 	MaxIdleConns      int           `env:"REDIS_MAX_IDLE_CONNS,default=1"`
 	MaxActiveConns    int           `env:"REDIS_MAX_ACTIVE_CONNS,default=50"`
+	MaxConnLifetime   time.Duration `env:"REDIS_MAX_CONN_LIFETIME,default=0s"`
 	IdleTimeout       time.Duration `env:"REDIS_IDLE_TIMEOUT,default=0s"`
 	IdleProbeInterval time.Duration `env:"REDIS_IDLE_PROBE_INTERVAL,default=0s"`
 	AttachmentNames   []string      `env:"REDIS_ATTACHMENT_NAMES"`
@@ -48,9 +49,10 @@ func newPool(cfg Config) *redis.Pool {
 			}
 			return conn, nil
 		},
-		MaxIdle:     cfg.MaxIdleConns,
-		MaxActive:   cfg.MaxActiveConns,
-		IdleTimeout: cfg.IdleTimeout,
+		MaxIdle:         cfg.MaxIdleConns,
+		MaxActive:       cfg.MaxActiveConns,
+		MaxConnLifetime: cfg.MaxConnLifetime,
+		IdleTimeout:     cfg.IdleTimeout,
 		TestOnBorrow: func(conn redis.Conn, t time.Time) error {
 			var err error
 			if cfg.IdleProbeInterval > 0 && time.Since(t) > cfg.IdleProbeInterval {


### PR DESCRIPTION
## Rationale

We have seen leaking connection counts when missing to close redis  connections after `Get` from a pool. The redigo pool supports a `MaxConnLifetime` config 
(see https://github.com/gomodule/redigo/blob/master/redis/pool.go#L160-L162) which when set to non zero automatically closes connections older than the set duration.

## Changes
Here we introduce a new environment variable `REDIS_MAX_CONN_LIFETIME` which defaults to `0s` to retain the original behaviour.
