### PR TITLE
Fix OC Agent / document cmdutil.Server and related / add examples.

### DIFF
--- a/cmdutil/server.go
+++ b/cmdutil/server.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Server runs synchronously and returns any errors. The Run method is expected
-// to block until Stop is called or return an error asap. Servers are typically
+// to block until finished, returning any error, or until Stop is called.
 // used with oklog/run.Group, where the first Server.Run to return will cancel
 // the Group (regardless of the error returned). Use NewContextServer to create
 // a Server that can block on a Context until Stop is called.


### PR DESCRIPTION
ocagent.Exporter.Start() returns immediately, which violates oklog/run.Group semantics, so use NewContextServer instead to block until something else brings down the Group.

Also updated the documentation for the various Server types and created some rudimentary examples in hopes that future readers won't fall into the same traps that I did.