### PR TITLE
Added new gRPC DialH2CContext function to supplant DialH2C

### DIFF
--- a/grpc/grpcclient/h2c.go
+++ b/grpc/grpcclient/h2c.go
@@ -1,6 +1,7 @@
 package grpcclient
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -11,37 +12,43 @@ import (
 	"google.golang.org/grpc"
 )
 
-// DialH2C will establish a connection to the grpcserver.NewStandardH2C server
+// DialH2CContext will establish a connection to the grpcserver.NewStandardH2C server
 // listening at the passed in URL, and return a connection for it. This will
-// _not_ register it in the client registry, that is left to the user.
-func DialH2C(serverURL string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	ou, err := url.Parse(serverURL)
+// _not_ register it in the client registry, that is left to the user. By default the call is non-blocking.
+// Use WithBlock for a blocking call. In the blocking case, ctx can be used to cancel or expire the pending connection.
+func DialH2CContext(ctx context.Context, serverURL string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	u, err := url.Parse(serverURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error parsing provided URL")
 	}
+	opts = append(opts,
+		grpc.WithContextDialer(h2c.Dialer{URL: u}.DialGRPCContext),
+		// TLS is done at the HTTP/1.1 level, so we never know....
+		grpc.WithInsecure(),
+	)
 
-	port := ou.Port()
-	if ou.Port() == "" {
-		p, err := net.LookupPort("tcp", ou.Scheme)
+	port := u.Port()
+	if u.Port() == "" {
+		p, err := net.LookupPort("tcp", u.Scheme)
 		if err != nil {
-			return nil, fmt.Errorf("unable to determine default port for scheme %s", ou.Scheme)
+			return nil, fmt.Errorf("unable to determine default port for scheme %s", u.Scheme)
 		}
 		port = strconv.Itoa(p)
 	}
 
-	opts = append(opts, []grpc.DialOption{
-		//TODO: SA1019: grpc.WithDialer is deprecated: use WithContextDialer instead  (staticcheck)
-		grpc.WithDialer(h2c.Dialer{URL: ou}.DialGRPC), //nolint:staticcheck
-		// TLS is done at the HTTP/1.1 level, so we never know....
-		grpc.WithInsecure(),
-	}...)
-
-	conn, err := grpc.Dial(
-		net.JoinHostPort(ou.Hostname(), port),
-		opts...,
-	)
+	conn, err := grpc.DialContext(ctx, net.JoinHostPort(u.Hostname(), port), opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error dialing server")
 	}
 	return conn, nil
+
+}
+
+// DialH2C will establish a connection to the grpcserver.NewStandardH2C server
+// listening at the passed in URL, and return a connection for it. This will
+// _not_ register it in the client registry, that is left to the user.
+//
+// Deprecated: Use DialH2CContext instead.
+func DialH2C(serverURL string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return DialH2CContext(context.Background(), serverURL, opts...)
 }

--- a/hmiddleware/basicauth/grpc_test.go
+++ b/hmiddleware/basicauth/grpc_test.go
@@ -37,13 +37,13 @@ func TestGRPCPerRPCCredentialBasicAuth(t *testing.T) {
 	srv := httptest.NewServer(hSrv.Handler)
 	defer srv.Close()
 
-	conn, err := grpcclient.DialH2C(
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpcclient.DialH2CContext(
+		ctx,
 		srv.URL,
-		//TODO: grpc.WithTimeout is deprecated: use DialContext and context.WithTimeout instead.  (staticcheck)
-		grpc.WithTimeout(10*time.Second), //nolint:staticcheck
 		grpc.WithBlock(),
-		//TODO: SA1019: grpc.WithWaitForHandshake is deprecated: this is the default behavior, and this option will be removed after the 1.18 release.  (staticcheck)
-		grpc.WithWaitForHandshake(), //nolint:staticcheck
 		grpc.WithPerRPCCredentials(&GRPCCredentials{Username: "user", Password: "pass"}),
 	)
 	if err != nil {


### PR DESCRIPTION
DialH2C used many deprecated features so I deprecated DialH2C and provided DialH2CContext which takes a context argument and is current with existing gRPC implementation.