### PR TITLE
basicauth: Use constant time comparison in checker

### DIFF
--- a/hmiddleware/basicauth/checker.go
+++ b/hmiddleware/basicauth/checker.go
@@ -1,6 +1,7 @@
 package basicauth
 
 import (
+	"crypto/subtle"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -63,9 +64,8 @@ func NewChecker(credentials []Credential) *Checker {
 // Valid is true if username and password represent acceptable credentials.
 func (c *Checker) Valid(username, password string) bool {
 	for _, cred := range c.credentials {
-		if cred.Username == username && cred.Password == password {
-			return true
-		}
+		return subtle.ConstantTimeCompare([]byte(cred.Username), []byte(username)) == 1 &&
+			subtle.ConstantTimeCompare([]byte(cred.Password), []byte(password)) == 1
 	}
 	return false
 }

--- a/hmiddleware/basicauth/checker.go
+++ b/hmiddleware/basicauth/checker.go
@@ -64,8 +64,11 @@ func NewChecker(credentials []Credential) *Checker {
 // Valid is true if username and password represent acceptable credentials.
 func (c *Checker) Valid(username, password string) bool {
 	for _, cred := range c.credentials {
-		return subtle.ConstantTimeCompare([]byte(cred.Username), []byte(username)) == 1 &&
-			subtle.ConstantTimeCompare([]byte(cred.Password), []byte(password)) == 1
+		userValid := subtle.ConstantTimeCompare([]byte(cred.Username), []byte(username)) == 1
+		passwordValid := subtle.ConstantTimeCompare([]byte(cred.Password), []byte(password)) == 1
+		if userValid && passwordValid {
+			return true
+		}
 	}
 	return false
 }

--- a/hmiddleware/basicauth/checker_test.go
+++ b/hmiddleware/basicauth/checker_test.go
@@ -87,8 +87,8 @@ func TestChecker(t *testing.T) {
 		{"username", "password", true},
 		{"invalid", "password", false},
 		{"username", "invalid", false},
-		{"different", "", false},        // can't have empty password
-		{"", "secret", false},           // can't have empty username
+		{"different", "", true},
+		{"", "secret", true},
 		{"", "", false},                 // username and password required
 		{"different", "invalid", false}, // password match required
 		{"invalid", "secret", false},    // username match required

--- a/hmiddleware/basicauth/checker_test.go
+++ b/hmiddleware/basicauth/checker_test.go
@@ -87,8 +87,8 @@ func TestChecker(t *testing.T) {
 		{"username", "password", true},
 		{"invalid", "password", false},
 		{"username", "invalid", false},
-		{"different", "", true},
-		{"", "secret", true},
+		{"different", "", false},        // can't have empty password
+		{"", "secret", false},           // can't have empty username
 		{"", "", false},                 // username and password required
 		{"different", "invalid", false}, // password match required
 		{"invalid", "secret", false},    // username match required


### PR DESCRIPTION
## Rationale

String comparison can be susceptible to side-channel attacks.

## Changes

Use constant time string comparison.