### PR TITLE
Disable starting exporter if OC_AGENT_ADDR isn't set.

### DIFF
--- a/cmdutil/oc/open_census.go
+++ b/cmdutil/oc/open_census.go
@@ -14,9 +14,9 @@ import (
 //
 // TODO[freeformz]: Support the other ocagent.WithXX options
 type Config struct {
-	// AgentAddress in the form of 'host:port'. Defaults to localhost:55678
+	// AgentAddress in the form of 'host:port'. Leave empty to disable.
 	// (ocagent.WithAddress).
-	AgentAddress string `env:"OC_AGENT_ADDR,default=localhost:55678"`
+	AgentAddress string `env:"OC_AGENT_ADDR"`
 	// ReconnectionPeriod to use when reconnecting to the agent. Defaults to
 	// 5s.(ocagent.WithReconnectionPeriod).
 	ReconnectionPeriod time.Duration `env:"OC_RECONNECTION_PERIOD,default=5s"`

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -79,8 +79,14 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 	s.Add(debug.New(logger, sc.Debug.Port))
 	s.Add(signals.NewServer(logger, syscall.SIGINT, syscall.SIGTERM))
 
-	if o.enableOpenCensusTracing {
-		oce, err := oc.NewExporter(sc.OpenCensus.TraceConfig(), sc.OpenCensus.ExporterOptions(s.App)...)
+	// only setup an exporter if indicated && the AgentAddress is set
+	// this separates the code change saying yes, do tracing from
+	// the operational aspect of deciding where it goes.
+	if o.enableOpenCensusTracing && sc.OpenCensus.AgentAddress != "" {
+		oce, err := oc.NewExporter(
+			sc.OpenCensus.TraceConfig(),
+			sc.OpenCensus.ExporterOptions(s.App)...,
+		)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This provides and escape value from the coded intent to enable open
census tracing.