### PR TITLE
Add some package documentation

### DIFF
--- a/cleanurl/cleanurl.go
+++ b/cleanurl/cleanurl.go
@@ -1,3 +1,5 @@
+// Package cleanurl provides utilities for scrubbing basic auth credentials
+// from URLs.
 package cleanurl
 
 import "net/url"

--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -1,3 +1,15 @@
+// Package debug wraps the gops agent for use as a cmdutil-compatible Server.
+//
+// The debug server will be started on DEBUG_PORT (default 9999). Get a stack trace, profile memory, etc. by running the gops command line connected to locahost:9999 like:
+//
+//		$ gops stack localhost:9999
+//		goroutine 50 [running]:
+//		  runtime/pprof.writeGoroutineStacks(0x4a18a20, 0xc000010138, 0x0, 0x0)
+//		  	/usr/local/Cellar/go/1.13.5/libexec/src/runtime/pprof/pprof.go:679 +0x9d
+//		  runtime/pprof.writeGoroutine(0x4a18a20, 0xc000010138, 0x2, 0x0, 0x0)
+//		  ...
+//
+// Learn more about gops at https://github.com/google/gops.
 package debug
 
 import (

--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -1,6 +1,8 @@
 // Package debug wraps the gops agent for use as a cmdutil-compatible Server.
 //
-// The debug server will be started on DEBUG_PORT (default 9999). Get a stack trace, profile memory, etc. by running the gops command line connected to locahost:9999 like:
+// The debug server will be started on DEBUG_PORT (default 9999). Get a stack
+// trace, profile memory, etc. by running the gops command line connected to
+// locahost:9999 like:
 //
 //		$ gops stack localhost:9999
 //		goroutine 50 [running]:

--- a/cmdutil/health/serve.go
+++ b/cmdutil/health/serve.go
@@ -1,3 +1,4 @@
+// Package health provides cmdutil-compatible healthcheck utilities.
 package health
 
 import (

--- a/cmdutil/server.go
+++ b/cmdutil/server.go
@@ -1,3 +1,4 @@
+// Package cmdutil provides abstractions for building things which can be started and stopped as a part of a executable's process lifecycle.
 package cmdutil
 
 import (

--- a/cmdutil/server.go
+++ b/cmdutil/server.go
@@ -1,4 +1,5 @@
-// Package cmdutil provides abstractions for building things which can be started and stopped as a part of a executable's process lifecycle.
+// Package cmdutil provides abstractions for building things which can be
+// started and stopped as a part of a executable's process lifecycle.
 package cmdutil
 
 import (


### PR DESCRIPTION
There are a number of packages with no package documentation at the
moment, which can make it challenging to navigate the repo if you don't
already know what's there.

This adds some package docs for a few that were missing it,
working mostly alphabetically through the first few packages
at https://godoc.org/github.com/heroku/x#pkg-subdirectories.