### PR TITLE
Add appended request_id to headers

### DIFF
--- a/hcontext/requestid.go
+++ b/hcontext/requestid.go
@@ -8,6 +8,7 @@ package hcontext
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -30,7 +31,7 @@ func FromRequest(r *http.Request) (id string, ok bool) {
 
 	for _, try := range headersToSearch {
 		if id = r.Header.Get(try); id != "" {
-			newRID = newRID + "," + id
+			newRID = fmt.Sprintf("%s,%s", newRID, id)
 			r.Header.Set("X-Request-Id", newRID)
 			return newRID, true
 		}

--- a/hcontext/requestid.go
+++ b/hcontext/requestid.go
@@ -26,14 +26,16 @@ var headersToSearch = []string{
 // If one is found, it appends a new request ID and sets the comma separated value as the header.
 // If one is not found, it sets a new request ID as the header.
 func FromRequest(r *http.Request) (id string, ok bool) {
+	newRID := uuid.New().String()
+
 	for _, try := range headersToSearch {
 		if id = r.Header.Get(try); id != "" {
-			newRequestID := uuid.New().String() + "," + id
-			return newRequestID, true
+			newRID = newRID + "," + id
+			r.Header.Set("X-Request-Id", newRID)
+			return newRID, true
 		}
 	}
 
-	newRID := uuid.New().String()
 	r.Header.Set("X-Request-Id", newRID)
 	return newRID, false
 }

--- a/hcontext/requestid_test.go
+++ b/hcontext/requestid_test.go
@@ -59,6 +59,7 @@ func TestFromRequest_AppendsIncomingRequestID(t *testing.T) {
 	req.Header.Set("X-Request-Id", originalRequestID)
 	requestID, ok := FromRequest(req)
 	requestIDs := strings.Split(requestID, ",")
+	reqIDInHeader := req.Header.Get("X-Request-Id")
 
 	if !ok {
 		t.Fatalf("no RequestID found in Headers")
@@ -72,6 +73,9 @@ func TestFromRequest_AppendsIncomingRequestID(t *testing.T) {
 		t.Fatalf("second Request ID was %v, want %v", requestIDs[1], originalRequestID)
 	}
 
+	if reqIDInHeader != requestID {
+		t.Fatalf("request ID in header was %v, want %v", req.Header.Get("X-Request-Id"), requestID)
+	}
 }
 
 func TestRequestIDFromContext(t *testing.T) {


### PR DESCRIPTION
* If there is a X-Request-Id header, it was being added to the context but
not the headers
* Headers are what gets logged by the request_logger middleware so
adding to headers is helpful for logging/splunking
* https://gus.my.salesforce.com/a07B00000078HcyIAE