### PR TITLE
Update go-grpc-middleware to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/gops v0.3.7
 	github.com/google/uuid v1.1.1
-	github.com/grpc-ecosystem/go-grpc-middleware v1.1.1-0.20200128160657-3c51f7f33212
+	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.9.6
 	github.com/heroku/rollrus v0.1.1
 	github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.1-0.20200128160657-3c51f7f33212 h1:HUq3xgyOFru7D8+Mv4oSXBmLHOo9NuwERUmQP+DhEFk=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.1-0.20200128160657-3c51f7f33212/go.mod h1:mJzapYve32yjrKlk9GbyCZHuPgZsrbyIbyKhSzOpg6s=
+github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 h1:0IKlLyQ3Hs9nDaiK5cSHAGmcQEIC8l2Ts1u6x5Dfrqg=
+github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9GbyCZHuPgZsrbyIbyKhSzOpg6s=
 github.com/grpc-ecosystem/grpc-gateway v1.9.4/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.6 h1:8p0pcgLlw2iuZVsdHdPaMUXFOA+6gDixcXbHEMzSyW8=
 github.com/grpc-ecosystem/grpc-gateway v1.9.6/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=


### PR DESCRIPTION
We had originally pointed at master for #123, though it has since been
tagged at v1.2.0: https://github.com/grpc-ecosystem/go-grpc-middleware/issues/259

/cc @bernerdschaefer 