### PR TITLE
testing/testlog: add New function

### DIFF
--- a/cmdutil/service/standard_http_test.go
+++ b/cmdutil/service/standard_http_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestStandardHTTPServer(t *testing.T) {
-	l, _ := testlog.NewNullLogger()
+	l, _ := testlog.New()
 	srv := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if _, err := io.WriteString(w, "OK"); err != nil {
@@ -56,7 +56,7 @@ func TestStandardHTTPServer(t *testing.T) {
 }
 
 func TestBypassHTTPServer(t *testing.T) {
-	l, _ := testlog.NewNullLogger()
+	l, _ := testlog.New()
 	srv := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if _, err := io.WriteString(w, "OK"); err != nil {
@@ -126,7 +126,7 @@ func TestHTTPServerConfiguration(t *testing.T) {
 		configuredServers = append(configuredServers, s.Addr)
 	}
 
-	l, _ := testlog.NewNullLogger()
+	l, _ := testlog.New()
 	p := testmetrics.NewProvider(t)
 	HTTP(l, p, nil, WithHTTPServerHook(config))
 

--- a/cmdutil/signals/signals_test.go
+++ b/cmdutil/signals/signals_test.go
@@ -23,7 +23,7 @@ func TestWithNotifyCancel(t *testing.T) {
 }
 
 func TestNewServer(t *testing.T) {
-	logger, _ := testlog.NewNullLogger()
+	logger, _ := testlog.New()
 
 	sv := NewServer(logger, syscall.SIGWINCH)
 
@@ -71,7 +71,7 @@ func TestNewServer(t *testing.T) {
 // Ensure Run returns when Stop is called, even if no signal
 // has been received.
 func TestNewServerNoSignal(t *testing.T) {
-	logger, _ := testlog.NewNullLogger()
+	logger, _ := testlog.New()
 
 	sv := NewServer(logger, syscall.SIGWINCH)
 

--- a/grpc/panichandler/panichandler_test.go
+++ b/grpc/panichandler/panichandler_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestLoggingUnaryPanicHandler_NoPanic(t *testing.T) {
-	l, hook := testlog.NewNullLogger()
+	l, hook := testlog.New()
 
 	var (
 		uhCalled bool
@@ -47,7 +47,7 @@ func TestLoggingUnaryPanicHandler_NoPanic(t *testing.T) {
 }
 
 func TestLoggingUnaryPanicHandler_Panic(t *testing.T) {
-	l, hook := testlog.NewNullLogger()
+	l, hook := testlog.New()
 
 	var (
 		uhCalled bool
@@ -79,7 +79,7 @@ func TestLoggingUnaryPanicHandler_Panic(t *testing.T) {
 }
 
 func TestLoggingStreamPanicHandler_NoPanic(t *testing.T) {
-	l, hook := testlog.NewNullLogger()
+	l, hook := testlog.New()
 
 	var (
 		shCalled bool
@@ -108,7 +108,7 @@ func TestLoggingStreamPanicHandler_NoPanic(t *testing.T) {
 }
 
 func TestLoggingStreamPanicHandler_Panic(t *testing.T) {
-	l, hook := testlog.NewNullLogger()
+	l, hook := testlog.New()
 
 	var (
 		shCalled bool

--- a/hmiddleware/basicauth/grpc_test.go
+++ b/hmiddleware/basicauth/grpc_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestGRPCPerRPCCredentialBasicAuth(t *testing.T) {
-	l, _ := testlog.NewNullLogger()
+	l, _ := testlog.New()
 	mux := http.NewServeMux()
 
 	checker := NewChecker([]Credential{{"user", "pass"}})

--- a/hmiddleware/logger_test.go
+++ b/hmiddleware/logger_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPreRequestLogger(t *testing.T) {
-	logger, hook := testlog.NewNullLogger()
+	logger, hook := testlog.New()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -40,7 +40,7 @@ func TestPreRequestLogger(t *testing.T) {
 }
 
 func TestPreRequestLoggerDoesNotDoubleWrapTheResponseWriter(t *testing.T) {
-	logger, hook := testlog.NewNullLogger()
+	logger, hook := testlog.New()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ww, ok := w.(middleware.WrapResponseWriter)
@@ -77,7 +77,7 @@ func TestPreRequestLoggerDoesNotDoubleWrapTheResponseWriter(t *testing.T) {
 }
 
 func TestPostRequestLogger(t *testing.T) {
-	logger, hook := testlog.NewNullLogger()
+	logger, hook := testlog.New()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -104,7 +104,7 @@ func TestPostRequestLogger(t *testing.T) {
 }
 
 func TestPostRequestLoggerDoesNotDoubleWrapTheResponseWriter(t *testing.T) {
-	logger, hook := testlog.NewNullLogger()
+	logger, hook := testlog.New()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ww, ok := w.(middleware.WrapResponseWriter)
@@ -213,7 +213,7 @@ func runPostRequestLoggerTest(t testing.TB, h http.Handler, hook *testlog.Hook) 
 }
 
 func TestRobotAllLogger(t *testing.T) {
-	logger, hook := testlog.NewNullLogger()
+	logger, hook := testlog.New()
 	defer hook.Reset()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/hmiddleware/request_logger_test.go
+++ b/hmiddleware/request_logger_test.go
@@ -26,7 +26,7 @@ func TestNewLogEntry(t *testing.T) {
 
 func TestLogEntryWrite(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)
-	logger, hook := testlog.NewNullLogger()
+	logger, hook := testlog.New()
 	l := &StructuredLogger{
 		Logger: logger,
 	}
@@ -46,7 +46,7 @@ func TestLogEntryWrite(t *testing.T) {
 
 func TestLogEntryPanic(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)
-	logger, hook := testlog.NewNullLogger()
+	logger, hook := testlog.New()
 	l := &StructuredLogger{
 		Logger: logger,
 	}

--- a/testing/testlog/example_test.go
+++ b/testing/testlog/example_test.go
@@ -1,0 +1,28 @@
+package testlog_test
+
+import (
+	"testing"
+
+	"github.com/heroku/x/testing/testlog"
+)
+
+func Example() {
+	var t *testing.T // use t provided by test function
+
+	logger, hook := testlog.New()
+
+	// Use the test logger
+	logger.WithField("a", "b").Info("test")
+
+	hook.CheckAllContained(t, "a=b", "msg=test")
+	hook.CheckNotContained(t, "unexpected")
+}
+
+func Example_discard() {
+	logger, _ := testlog.New()
+
+	// Use the test logger
+	logger.WithField("a", "b").Info("test")
+
+	// Output:
+}

--- a/testing/testlog/testlog.go
+++ b/testing/testlog/testlog.go
@@ -1,3 +1,4 @@
+// Package testlog provides a test logger and helpers to check log output.
 package testlog
 
 import (
@@ -17,8 +18,9 @@ type Hook struct {
 	entries []*logrus.Entry
 }
 
-// NewNullLogger Creates a discarding logger and installs the test hook.
-func NewNullLogger() (*logrus.Logger, *Hook) {
+// New sets up a test logger that produces no output. Use the returned hook to
+// observe and make assertions about what was logged.
+func New() (*logrus.Logger, *Hook) {
 	l := logrus.New()
 	l.Out = ioutil.Discard
 
@@ -26,7 +28,13 @@ func NewNullLogger() (*logrus.Logger, *Hook) {
 	l.Hooks.Add(hook)
 
 	return l, hook
+}
 
+// NewNullLogger Creates a discarding logger and installs the test hook.
+//
+// Deprecated: Use New instead.
+func NewNullLogger() (*logrus.Logger, *Hook) {
+	return New()
 }
 
 // Entries is a thread safe accessor for all entries.


### PR DESCRIPTION
The testlog package's function to get a test logger was `NewNullLogger`,
which was used to match the function name in logrus' hook test package.
Most folks using this package now, however, have not used the logrus
package, and there are no other kinds of test loggers in the package, so
using `New` instead reads better.

This also documents the package and adds examples.