### PR TITLE
logplex/encoding: timestamp padding

### DIFF
--- a/logplex/encoding/encoder.go
+++ b/logplex/encoding/encoder.go
@@ -14,6 +14,9 @@ const SyslogTimeFormat = "2006-01-02T15:04:05.999999-07:00"
 // FlexibleSyslogTimeFormat accepts both 'Z' and TZ notation for event time.
 const FlexibleSyslogTimeFormat = "2006-01-02T15:04:05.999999Z07:00"
 
+// HumanTimeFormat defines the human friendly time format used in CLI/UI.
+const HumanTimeFormat = "2006-01-02T15:04:05.000000-07:00"
+
 // L15Error is the message returned with an L15 error
 const L15Error = "L15: Error displaying log lines. Please try again."
 
@@ -88,7 +91,7 @@ func (s *sseEncoder) separator() {
 }
 
 func messageToString(msg Message) string {
-	return fmt.Sprintf("%s %s[%s]: %s", msg.Timestamp.Format(SyslogTimeFormat), msg.Application, msg.Process, msg.Message)
+	return fmt.Sprintf("%s %s[%s]: %s", msg.Timestamp.Format(HumanTimeFormat), msg.Application, msg.Process, msg.Message)
 }
 
 // Encode serializes a syslog message into their wire format ( octet-framed syslog )

--- a/logplex/encoding/encoder_test.go
+++ b/logplex/encoding/encoder_test.go
@@ -102,7 +102,7 @@ func TestEncoderTypes(t *testing.T) {
 				Timestamp:   lockedDate,
 				Message:     "hi",
 			},
-			wantEncodedMsg: "2019-01-12T11:45:26.371+00:00 application[process]: hi",
+			wantEncodedMsg: "2019-01-12T11:45:26.371000+00:00 application[process]: hi",
 		},
 		{
 			name:        "successful encoding with SSE encoder",
@@ -117,7 +117,7 @@ func TestEncoderTypes(t *testing.T) {
 				Timestamp:   lockedDate,
 				Message:     "hi",
 			},
-			wantEncodedMsg: "id: 1547293526\ndata: 2019-01-12T11:45:26.371+00:00 application[process]: hi\n\n\n",
+			wantEncodedMsg: "id: 1547293526\ndata: 2019-01-12T11:45:26.371000+00:00 application[process]: hi\n\n\n",
 		},
 	}
 


### PR DESCRIPTION
Make our Go timestamp encoding like Logplex (erlang), padding seconds up to 6 places.

Before

```
2020-03-10T15:36:08.21395+00:00 app[publish.1]: time="2020-03-10T15:36:08Z" level=info msg="report tick"
2020-03-10T15:36:09.213969+00:00 app[publish.1]: time="2020-03-10T15:36:09Z" level=info msg="report tick"
```

After

```
2020-03-10T15:36:08.213950+00:00 app[publish.1]: time="2020-03-10T15:36:08Z" level=info msg="report tick"
2020-03-10T15:36:09.213969+00:00 app[publish.1]: time="2020-03-10T15:36:09Z" level=info msg="report tick"
```