### PR TITLE
Adding Timeout Configs to config.go

### DIFF
--- a/cmdutil/https/config.go
+++ b/cmdutil/https/config.go
@@ -1,5 +1,7 @@
 package https
 
+import "time"
+
 // Config for HTTP and HTTPS servers.
 type Config struct {
 	InsecurePort int `env:"HEROKU_ROUTER_HTTP_PORT,required"`
@@ -7,7 +9,9 @@ type Config struct {
 
 	// These environement variables are automatically set by ACM in
 	// relation to Let's Encrypt certificates.
-	ServerCert  string `env:"SERVER_CERT,required"`
-	ServerKey   string `env:"SERVER_KEY,required"`
-	UseAutocert bool   `env:"HTTPS_USE_AUTOCERT"`
+	ServerCert   string        `env:"SERVER_CERT,required"`
+	ServerKey    string        `env:"SERVER_KEY,required"`
+	UseAutocert  bool          `env:"HTTPS_USE_AUTOCERT"`
+	ReadTimeout  time.Duration `env:"READ_TIMEOUT"`
+	WriteTimeout time.Duration `env:"WRITE_TIMEOUT"`
 }

--- a/cmdutil/https/config.go
+++ b/cmdutil/https/config.go
@@ -7,11 +7,12 @@ type Config struct {
 	InsecurePort int `env:"HEROKU_ROUTER_HTTP_PORT,required"`
 	SecurePort   int `env:"HEROKU_ROUTER_HTTPS_PORT,required"`
 
-	// These environement variables are automatically set by ACM in
+	// These environment variables are automatically set by ACM in
 	// relation to Let's Encrypt certificates.
-	ServerCert   string        `env:"SERVER_CERT,required"`
-	ServerKey    string        `env:"SERVER_KEY,required"`
-	UseAutocert  bool          `env:"HTTPS_USE_AUTOCERT"`
-	ReadTimeout  time.Duration `env:"READ_TIMEOUT"`
-	WriteTimeout time.Duration `env:"WRITE_TIMEOUT"`
+	ServerCert  string `env:"SERVER_CERT,required"`
+	ServerKey   string `env:"SERVER_KEY,required"`
+	UseAutocert bool   `env:"HTTPS_USE_AUTOCERT"`
+	// These environment variables are set with default values of 60s
+	ReadTimeout  time.Duration `env:"HTTP_SERVER_READ_TIMEOUT,default=60s"`
+	WriteTimeout time.Duration `env:"HTTP_SERVER_WRITE_TIMEOUT,default=60s"`
 }

--- a/cmdutil/https/serve.go
+++ b/cmdutil/https/serve.go
@@ -21,8 +21,8 @@ func Serve(handler http.Handler, cfg Config, opts ...func(*http.Server)) error {
 		serverCert = []byte(cfg.ServerCert)
 		serverKey  = []byte(cfg.ServerKey)
 		srv        = &http.Server{
-			Addr:    fmt.Sprintf(":%d", cfg.SecurePort),
-			Handler: handler,
+			Addr:         fmt.Sprintf(":%d", cfg.SecurePort),
+			Handler:      handler,
 			WriteTimeout: cfg.WriteTimeout * time.Second,
 			ReadTimeout:  cfg.ReadTimeout * time.Second,
 		}

--- a/cmdutil/https/serve.go
+++ b/cmdutil/https/serve.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"time"
 
 	proxyproto "github.com/armon/go-proxyproto"
 	"github.com/pkg/errors"

--- a/cmdutil/https/serve.go
+++ b/cmdutil/https/serve.go
@@ -23,8 +23,8 @@ func Serve(handler http.Handler, cfg Config, opts ...func(*http.Server)) error {
 		srv        = &http.Server{
 			Addr:         fmt.Sprintf(":%d", cfg.SecurePort),
 			Handler:      handler,
-			WriteTimeout: cfg.WriteTimeout * time.Second,
-			ReadTimeout:  cfg.ReadTimeout * time.Second,
+			WriteTimeout: cfg.WriteTimeout,
+			ReadTimeout:  cfg.ReadTimeout,
 		}
 	)
 

--- a/cmdutil/https/serve.go
+++ b/cmdutil/https/serve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	proxyproto "github.com/armon/go-proxyproto"
 	"github.com/pkg/errors"
@@ -22,6 +23,8 @@ func Serve(handler http.Handler, cfg Config, opts ...func(*http.Server)) error {
 		srv        = &http.Server{
 			Addr:    fmt.Sprintf(":%d", cfg.SecurePort),
 			Handler: handler,
+			WriteTimeout: cfg.WriteTimeout * time.Second,
+			ReadTimeout:  cfg.ReadTimeout * time.Second,
 		}
 	)
 


### PR DESCRIPTION
Adding Read and Write timeout properties. These values can serve as failsafes should the component's load balancer i.e ELB no longer implement timeouts for some reason. This is a defence-in-depth measure.