### PR TITLE
Adding Read and Write timeouts for http.server

### DIFF
--- a/cmdutil/https/serve.go
+++ b/cmdutil/https/serve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	proxyproto "github.com/armon/go-proxyproto"
 	"github.com/pkg/errors"
@@ -22,6 +23,8 @@ func Serve(handler http.Handler, cfg Config, opts ...func(*http.Server)) error {
 		srv        = &http.Server{
 			Addr:    fmt.Sprintf(":%d", cfg.SecurePort),
 			Handler: handler,
+			WriteTimeout: cfg.WriteTimeout * time.Second,
+			ReadTimeout:  cfg.ReadTimeout * time.Second,
 		}
 	)
 


### PR DESCRIPTION
Adding the timeouts defined in the provided config for the &http.Server.Using the timeout properties added in this PR https://github.com/heroku/x/pull/130