### PR TITLE
hmiddleware: add connection closing middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.9.6
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/heroku/rollrus v0.1.1
 	github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.4/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.6 h1:8p0pcgLlw2iuZVsdHdPaMUXFOA+6gDixcXbHEMzSyW8=
 github.com/grpc-ecosystem/grpc-gateway v1.9.6/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/heroku/rollrus v0.1.1 h1:QBXJGBGgPmJxW1PX2+vd5eP+H/w0ULt/PEkguHZa+Qo=
 github.com/heroku/rollrus v0.1.1/go.mod h1:B3MwEcr9nmf4xj0Sr5l9eSht7wLKMa1C+9ajgAU79ek=

--- a/hmiddleware/connection_closer.go
+++ b/hmiddleware/connection_closer.go
@@ -27,7 +27,7 @@ func ConnectionClosingContext(ctx context.Context, c net.Conn) context.Context {
 // ConnContext field.
 func ConnectionClosingMiddleware(mp metrics.Provider, maxRequests, cacheSize int) (func(http.Handler) http.Handler, error) {
 	var (
-		closed = mp.NewCounter("server.connection.closes.total")
+		closed = mp.NewCounter("connection.closes.total")
 		mtx    sync.Mutex
 	)
 

--- a/hmiddleware/connection_closer.go
+++ b/hmiddleware/connection_closer.go
@@ -1,0 +1,75 @@
+package hmiddleware
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/golang-lru"
+	"github.com/heroku/x/go-kit/metrics"
+)
+
+type connCloseKey int
+
+var connCloseID connCloseKey
+
+// ConnectionClosingContext adds a unique identifier to the context for a newly established connection. This function
+// is meant to be used as an http.Server's ConnContext field, and is required for the ConnectionClosingMiddleware.
+func ConnectionClosingContext(ctx context.Context, c net.Conn) context.Context {
+	return context.WithValue(ctx, connCloseID, uuid.New().String())
+}
+
+// ConnectionClosingMiddleware returns middleware that will add a "Connection: close" responses header after a single
+// connection has produced maxRequests http requests. The cacheSize determines the size of the LRU cache which tracks
+// connection request counts. This middleware requires the http.Server sets ConnectionClosingContext for it's
+// ConnContext field.
+func ConnectionClosingMiddleware(mp metrics.Provider, maxRequests, cacheSize int) func(http.Handler) http.Handler {
+	var (
+		closed = mp.NewCounter("server.connection.closes.total")
+		mtx    sync.Mutex
+	)
+
+	cache, err := lru.New(cacheSize)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			shouldClose := false
+			connID, ok := r.Context().Value(connCloseID).(string)
+
+			if ok {
+				// In the case of http/1.x requests are served serially per connection, and locking isn't necessary.
+				// However this isn't necessarily true for the http/2 path. So we lock here for correctness.
+				mtx.Lock()
+
+				requests := 0
+				requestValue, ok := cache.Get(connID)
+				if ok {
+					requests = requestValue.(int)
+				}
+
+				requests++
+				if requests >= maxRequests {
+					shouldClose = true
+					cache.Remove(connID)
+				} else {
+					cache.Add(connID, requests)
+				}
+
+				mtx.Unlock()
+			}
+
+			next.ServeHTTP(w, r)
+
+			if shouldClose {
+				closed.Add(1)
+				w.Header().Add("connection", "close")
+			}
+		})
+	}
+}

--- a/hmiddleware/connection_closer.go
+++ b/hmiddleware/connection_closer.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/heroku/x/go-kit/metrics"
 )
 

--- a/hmiddleware/connection_closer.go
+++ b/hmiddleware/connection_closer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru"
+
 	"github.com/heroku/x/go-kit/metrics"
 )
 

--- a/hmiddleware/connection_closer_test.go
+++ b/hmiddleware/connection_closer_test.go
@@ -105,7 +105,7 @@ func TestConnectionClosingMiddleware(t *testing.T) {
 				t.Fatalf("want unique connects: %d, got %d", want, got)
 			}
 
-			mp.CheckCounter("server.connection.closes.total", float64(test.wantCloseHeaders))
+			mp.CheckCounter("connection.closes.total", float64(test.wantCloseHeaders))
 
 			if want, got := test.wantCloseHeaders, gotCloseHeader; want != got {
 				t.Fatalf("want close header count: %d, got %d", want, got)

--- a/hmiddleware/connection_closer_test.go
+++ b/hmiddleware/connection_closer_test.go
@@ -23,11 +23,11 @@ func TestConnectionClosingContext(t *testing.T) {
 
 func TestConnectionClosingMiddleware(t *testing.T) {
 	tests := []struct {
-		name                 string
-		maxRequests          int
-		requestCount         int
-		wantConnections      int
-		wantCloseHeaders     int
+		name             string
+		maxRequests      int
+		requestCount     int
+		wantConnections  int
+		wantCloseHeaders int
 	}{
 		{
 			name:            "too few requests",
@@ -36,18 +36,18 @@ func TestConnectionClosingMiddleware(t *testing.T) {
 			wantConnections: 1,
 		},
 		{
-			name:                 "exactly max requests",
-			maxRequests:          10,
-			requestCount:         10,
-			wantConnections:      1,
-			wantCloseHeaders:     1,
+			name:             "exactly max requests",
+			maxRequests:      10,
+			requestCount:     10,
+			wantConnections:  1,
+			wantCloseHeaders: 1,
 		},
 		{
-			name:                 "several times max requests",
-			maxRequests:          10,
-			requestCount:         100,
-			wantConnections:      10,
-			wantCloseHeaders:     10,
+			name:             "several times max requests",
+			maxRequests:      10,
+			requestCount:     100,
+			wantConnections:  10,
+			wantCloseHeaders: 10,
 		},
 	}
 
@@ -76,7 +76,7 @@ func TestConnectionClosingMiddleware(t *testing.T) {
 			handler = middleware(handler)
 
 			server := httptest.NewUnstartedServer(handler)
-			server.Config.ConnContext = ConnectionClosingContext
+			server.Config.ConnContext = ConnectionClosingContext //nolint:typecheck
 			server.Start()
 			defer server.Close()
 

--- a/hmiddleware/connection_closer_test.go
+++ b/hmiddleware/connection_closer_test.go
@@ -1,0 +1,96 @@
+package hmiddleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/heroku/x/go-kit/metrics/provider/discard"
+	"github.com/heroku/x/go-kit/metrics/testmetrics"
+)
+
+func TestConnectionClosingContext(t *testing.T) {
+	ctx := ConnectionClosingContext(context.TODO(), nil)
+	connID := ctx.Value(connCloseID).(string)
+	if connID == "" {
+		t.Fatal("want connection id in context, got nil")
+	}
+}
+
+func TestConnectionClosingMiddleware(t *testing.T) {
+	tests := []struct {
+		name                 string
+		maxRequests          int
+		requestCount         int
+		wantCloseMetricCount float64
+		wantCloseHeaders     int
+	}{
+		{
+			name:         "too few requests",
+			maxRequests:  10,
+			requestCount: 5,
+		},
+		{
+			name:                 "exactly max requests",
+			maxRequests:          10,
+			requestCount:         10,
+			wantCloseMetricCount: 1,
+			wantCloseHeaders:     1,
+		},
+		{
+			name:                 "several times max requests",
+			maxRequests:          10,
+			requestCount:         100,
+			wantCloseMetricCount: 10,
+			wantCloseHeaders:     10,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mp := testmetrics.NewProvider(t)
+			ctx := ConnectionClosingContext(context.TODO(), nil)
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("hello world"))
+			})
+
+			middleware := ConnectionClosingMiddleware(mp, test.maxRequests, 1024)
+			handler := middleware(next)
+
+			gotCloseHeader := 0
+			for i := 0; i < test.requestCount; i++ {
+				req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+				recorder := httptest.NewRecorder()
+
+				handler.ServeHTTP(recorder, req)
+
+				if recorder.Header().Get("connection") == "close" {
+					gotCloseHeader++
+				}
+			}
+
+			mp.CheckCounter("server.connection.closes.total", test.wantCloseMetricCount)
+
+			if want, got := test.wantCloseHeaders, gotCloseHeader; want != got {
+				t.Fatalf("want close header count: %d, got %d", want, got)
+			}
+		})
+	}
+}
+
+func BenchmarkConnectionClosingMiddleware_Cache1024(b *testing.B) {
+	middleware := ConnectionClosingMiddleware(discard.New(), 100, 1024)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello world"))
+	})
+	handler := middleware(next)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx := ConnectionClosingContext(context.TODO(), nil)
+		req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+	}
+}


### PR DESCRIPTION
We'd like the ability to cooperatively close connections once we've received a certain number of requests, to avoid the pinning of high traffic connections to a particular server process.