### PR TITLE
logplex/encoding: Improve encoding performance

### DIFF
--- a/logplex/encoding/encoder.go
+++ b/logplex/encoding/encoder.go
@@ -107,17 +107,14 @@ func Encode(msg Message) ([]byte, error) {
 		return nil, errors.Wrap(ErrInvalidMessage, "version")
 	}
 
-	line := fmt.Sprintf("<%d>%d %s %s %s %s %s %s%s",
-		msg.Priority,
-		msg.Version,
-		msg.Timestamp.Format(SyslogTimeFormat),
-		stringOrNil(msg.Hostname),
-		stringOrNil(msg.Application),
-		stringOrNil(msg.Process),
-		stringOrNil(msg.ID),
-		sd,
-		msg.Message,
-	)
+	line := "<" + strconv.Itoa(int(msg.Priority)) + ">" + strconv.Itoa(int(msg.Version)) + " " +
+		msg.Timestamp.Format(SyslogTimeFormat) + " " +
+		stringOrNil(msg.Hostname) + " " +
+		stringOrNil(msg.Application) + " " +
+		stringOrNil(msg.Process) + " " +
+		stringOrNil(msg.ID) + " " +
+		sd +
+		msg.Message
 
 	return []byte(strconv.Itoa(len(line)) + " " + line), nil
 }

--- a/logplex/encoding/encoder.go
+++ b/logplex/encoding/encoder.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -93,15 +92,7 @@ func (s *sseEncoder) separator() {
 
 func messageToString(msg Message) string {
 	// equivalent to fmt.Sprintf("%s %s[%s]: %s", msg.Timestamp.Format(HumanTimeFormat), msg.Application, msg.Process, msg.Message)
-	var s strings.Builder
-	s.WriteString(msg.Timestamp.Format(HumanTimeFormat))
-	s.WriteString(" ")
-	s.WriteString(msg.Application)
-	s.WriteString("[")
-	s.WriteString(msg.Process)
-	s.WriteString("]: ")
-	s.WriteString(msg.Message)
-	return s.String()
+	return msg.Timestamp.Format(HumanTimeFormat) + " " + msg.Application + "[" + msg.Process + "]: " + msg.Message
 }
 
 // Encode serializes a syslog message into their wire format ( octet-framed syslog )

--- a/logplex/encoding/encoder.go
+++ b/logplex/encoding/encoder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -91,7 +92,16 @@ func (s *sseEncoder) separator() {
 }
 
 func messageToString(msg Message) string {
-	return fmt.Sprintf("%s %s[%s]: %s", msg.Timestamp.Format(HumanTimeFormat), msg.Application, msg.Process, msg.Message)
+	// equivalent to fmt.Sprintf("%s %s[%s]: %s", msg.Timestamp.Format(HumanTimeFormat), msg.Application, msg.Process, msg.Message)
+	var s strings.Builder
+	s.WriteString(msg.Timestamp.Format(HumanTimeFormat))
+	s.WriteString(" ")
+	s.WriteString(msg.Application)
+	s.WriteString("[")
+	s.WriteString(msg.Process)
+	s.WriteString("]: ")
+	s.WriteString(msg.Message)
+	return s.String()
 }
 
 // Encode serializes a syslog message into their wire format ( octet-framed syslog )

--- a/logplex/encoding/encoder.go
+++ b/logplex/encoding/encoder.go
@@ -91,7 +91,6 @@ func (s *sseEncoder) separator() {
 }
 
 func messageToString(msg Message) string {
-	// equivalent to fmt.Sprintf("%s %s[%s]: %s", msg.Timestamp.Format(HumanTimeFormat), msg.Application, msg.Process, msg.Message)
 	return msg.Timestamp.Format(HumanTimeFormat) + " " + msg.Application + "[" + msg.Process + "]: " + msg.Message
 }
 

--- a/logplex/encoding/encoder_test.go
+++ b/logplex/encoding/encoder_test.go
@@ -147,7 +147,10 @@ func TestEncoderTypes(t *testing.T) {
 var result string
 
 func BenchmarkMessageToString(b *testing.B) {
-	lockedDate, _ := time.Parse("2006-01-02T15:04:05.000Z", "2019-01-12T11:45:26.371Z")
+	lockedDate, err := time.Parse("2006-01-02T15:04:05.000Z", "2019-01-12T11:45:26.371Z")
+	if err != nil {
+		b.Fatal("unexpected error parsing benchmark input", err)
+	}
 	msg := Message{
 		Version:     1,
 		Priority:    134,
@@ -158,9 +161,35 @@ func BenchmarkMessageToString(b *testing.B) {
 		Timestamp:   lockedDate,
 		Message:     "hi",
 	}
+	var result string
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		result = messageToString(msg)
 	}
+	_ = result
+}
+
+func BenchmarkEncode(b *testing.B) {
+	lockedDate, err := time.Parse("2006-01-02T15:04:05.000Z", "2019-01-12T11:45:26.371Z")
+	if err != nil {
+		b.Fatal("unexpected error parsing benchmark input", err)
+	}
+	msg := Message{
+		Version:     1,
+		Priority:    134,
+		Hostname:    "hostname",
+		Application: "application",
+		Process:     "process",
+		ID:          "msgid",
+		Timestamp:   lockedDate,
+		Message:     "hi",
+	}
+	var result []byte
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		result, _ = Encode(msg)
+	}
+	_ = result
 }
 
 type failWrite struct{}

--- a/logplex/encoding/encoder_test.go
+++ b/logplex/encoding/encoder_test.go
@@ -144,8 +144,6 @@ func TestEncoderTypes(t *testing.T) {
 	}
 }
 
-var result string
-
 func BenchmarkMessageToString(b *testing.B) {
 	lockedDate, err := time.Parse("2006-01-02T15:04:05.000Z", "2019-01-12T11:45:26.371Z")
 	if err != nil {

--- a/logplex/encoding/encoder_test.go
+++ b/logplex/encoding/encoder_test.go
@@ -144,6 +144,25 @@ func TestEncoderTypes(t *testing.T) {
 	}
 }
 
+var result string
+
+func BenchmarkMessageToString(b *testing.B) {
+	lockedDate, _ := time.Parse("2006-01-02T15:04:05.000Z", "2019-01-12T11:45:26.371Z")
+	msg := Message{
+		Version:     1,
+		Priority:    134,
+		Hostname:    "hostname",
+		Application: "application",
+		Process:     "process",
+		ID:          "msgid",
+		Timestamp:   lockedDate,
+		Message:     "hi",
+	}
+	for n := 0; n < b.N; n++ {
+		result = messageToString(msg)
+	}
+}
+
 type failWrite struct{}
 
 func (failWrite) Write([]byte) (int, error) {


### PR DESCRIPTION
@freeformz was so kind to point out room for improvement here. Use `strings.Builder` instead of `fmt.Sprintf` to format logplex messages.