### PR TITLE
cmdutil/service: support service.New(nil)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,4 +8,4 @@ workflows:
       - golang/golangci-lint:
           version: "v1.18.0"
       - golang/test-nodb:
-          version: "1.13"
+          version: "1.14"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,6 @@ workflows:
   ci:
     jobs:
       - golang/golangci-lint:
-          version: "v1.18.0"
+          version: "v1.28.1"
       - golang/test-nodb:
           version: "1.14"

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -32,8 +32,10 @@ type Standard struct {
 }
 
 // New Standard Service with logging, rollbar, metrics, debugging, common signal
-// handling, and possibly more. envdecode.MustStrictDecode is called on the
-// provided appConfig to ensure that it is processed.
+// handling, and possibly more.
+//
+// If appConfig is non-nil, envdecode.MustStrictDecode will be called on it
+// to ensure that it is processed.
 func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 	// Initialize the pseudo-random number generator with a unique value so we
 	// get unique sequences across runs.
@@ -41,7 +43,10 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 
 	var sc standardConfig
 	envdecode.MustStrictDecode(&sc)
-	envdecode.MustStrictDecode(appConfig)
+
+	if appConfig != nil {
+		envdecode.MustStrictDecode(appConfig)
+	}
 
 	logger := svclog.NewLogger(sc.Logger)
 

--- a/cmdutil/service/standard_test.go
+++ b/cmdutil/service/standard_test.go
@@ -1,0 +1,57 @@
+package service_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/heroku/x/cmdutil/service"
+)
+
+func TestNewNoConfig(t *testing.T) {
+	setupStandardConfig(t)
+
+	s := service.New(nil)
+
+	if s.Logger == nil {
+		t.Fatal("standard logger not configured")
+	}
+
+	if s.MetricsProvider == nil {
+		t.Fatal("standard metrics provider not configured")
+	}
+}
+
+func TestNewCustomConfig(t *testing.T) {
+	setupStandardConfig(t)
+
+	os.Setenv("TEST_VAL", "1m")
+	defer os.Unsetenv("TEST_VAL")
+
+	var cfg struct {
+		Val time.Duration `env:"TEST_VAL"`
+	}
+	s := service.New(&cfg)
+
+	if s.Logger == nil {
+		t.Fatal("standard logger not configured")
+	}
+
+	if s.MetricsProvider == nil {
+		t.Fatal("standard metrics provider not configured")
+	}
+
+	if cfg.Val != time.Minute {
+		t.Fatalf("cfg.Val = %v want %v", cfg.Val, time.Minute)
+	}
+}
+
+func setupStandardConfig(t *testing.T) {
+	os.Setenv("APP_NAME", "test-app")
+	os.Setenv("DEPLOY", "test")
+
+	t.Cleanup(func() {
+		os.Unsetenv("APP_NAME")
+		os.Unsetenv("DEPLOY")
+	})
+}

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-kit/kit/metrics/generic"
 	"gopkg.in/caio/go-tdigest.v2"
 
-	"github.com/heroku/x/go-kit/metrics"
 	xmetrics "github.com/heroku/x/go-kit/metrics"
 )
 
@@ -176,7 +175,7 @@ func defaultErrorHandler(err error) {}
 
 // New librato metrics provider that reports metrics to the URL every interval
 // with the provided options.
-func New(u *url.URL, interval time.Duration, opts ...OptionFunc) metrics.Provider {
+func New(u *url.URL, interval time.Duration, opts ...OptionFunc) xmetrics.Provider {
 	p := Provider{
 		errorHandler:     defaultErrorHandler,
 		done:             make(chan struct{}),


### PR DESCRIPTION
envdecode requires that at least one field in a provided config struct
match from the environment. This sometimes makes the standard service
awkward to work with, particularly when gradually migrating an existing
system.

It's common to see this while getting started:

```go
var cfg struct {
  AppName string `env:"APP_NAME"` // mirror APP_NAME from svclog for envdecode
}
s := service.New(&cfg)
```

This updates `service.New` to accept nil for for the appConfig argument
to ease conversion of services.