### PR TITLE
logplex/encoding: NewDrainScanner takes a Reader

### DIFF
--- a/logplex/encoding/scanner.go
+++ b/logplex/encoding/scanner.go
@@ -158,8 +158,8 @@ func (s *syslogScanner) Scan() bool {
 }
 
 // NewDrainScanner returns a scanner for use with drain endpoints. The primary
-// difference is that it's lose and doesn't check for structured data.
-func NewDrainScanner(r io.ReadCloser) Scanner {
+// difference is that it's loose and doesn't check for structured data.
+func NewDrainScanner(r io.Reader) Scanner {
 	return newSyslogScanner(r, false)
 }
 


### PR DESCRIPTION
Requiring a ReadCloser is unnecessary since nothing in the encoding
process needs to call Close.