### PR TITLE
Add Helpers for 'Null Logger'

### DIFF
--- a/cmdutil/svclog/logger.go
+++ b/cmdutil/svclog/logger.go
@@ -2,6 +2,7 @@
 package svclog
 
 import (
+	"io/ioutil"
 	"strings"
 	"time"
 
@@ -82,4 +83,20 @@ type saramaLogger struct {
 func (sl saramaLogger) Printf(format string, args ...interface{}) {
 	format = strings.TrimSpace(format)
 	sl.FieldLogger.Printf(format, args...)
+}
+
+// NewNullLogger returns a logger that discards the output useful for testing
+func NewNullLogger() logrus.FieldLogger {
+	logger := logrus.New()
+	logger.SetOutput(ioutil.Discard)
+	return logger
+}
+
+// LoggerOrNull ensures non-nil logger is passed in or creates a Null Logger
+func LoggerOrNull(l logrus.FieldLogger) logrus.FieldLogger {
+	if l == nil {
+		return NewNullLogger()
+	}
+
+	return l
 }


### PR DESCRIPTION
I've noticed a number of cases where a logger might not be given so null logger is used. I figured it would be helpful to centralize the pattern.
