### PR TITLE
Add role validation to basicauth checking

### DIFF
--- a/hmiddleware/basicauth/checker.go
+++ b/hmiddleware/basicauth/checker.go
@@ -50,7 +50,14 @@ func parseCredential(credential string) (Credential, error) {
 // Checker stores a set of valid credentials to be used when authenticating
 // HTTP requests using basic auth.
 type Checker struct {
-	credentials []Credential
+	credentials   []Credential
+	roleValidator RoleValidator
+}
+
+// RoleValidator providers Validate() which returns true
+// if a role has access to a particular request method.
+type RoleValidator interface {
+	Validate(role, method string) bool
 }
 
 // NewChecker returns a basic auth checker configured to use credentials
@@ -59,6 +66,11 @@ func NewChecker(credentials []Credential) *Checker {
 	return &Checker{
 		credentials: credentials,
 	}
+}
+
+// WithRoleValidator sets the roleValidator on a Checker.
+func (c *Checker) WithRoleValidator(rv RoleValidator) {
+	c.roleValidator = rv
 }
 
 // Valid is true if username and password represent acceptable credentials.

--- a/hmiddleware/basicauth/grpc.go
+++ b/hmiddleware/basicauth/grpc.go
@@ -44,7 +44,10 @@ func GRPCAuthFunc(checker *Checker) func(ctx context.Context) (context.Context, 
 			}
 
 			if !checker.roleValidator.Validate(user, method) {
-				return nil, grpc.Errorf(codes.PermissionDenied, fmt.Sprintf("permission denied. user \"%s\" does not have access to \"%s\"", user, method)) //nolint:staticcheck
+				return nil, grpc.Errorf( //nolint:staticcheck
+					codes.PermissionDenied,
+					fmt.Sprintf("permission denied. user \"%s\" does not have access to \"%s\"", user, method),
+				)
 			}
 		}
 


### PR DESCRIPTION
## Reasons for making these changes

We'd like to extend the `basicauth` capabilities to include validation of role-based access. This [ADR](https://github.com/heroku/runtime/pull/4837) gives context.

## Description of changes

- Adds a `RoleValidator` interface that provides a `Validate(role, method string) bool` func that should return true when the `role` has access to `method`.
- Modifies `basicauth.GRPCAuthFunc` to call `roleValidator.Validate` if role validator is defined.
- Adds testing of the above.

## Runtime issue
https://trello.com/c/eEdSQMMa/193-implement-role-validator-in-heroku-x-basicauth
