### PR TITLE
Preserve query parameters when sending data to librato

### DIFF
--- a/go-kit/metrics/provider/librato/batcher.go
+++ b/go-kit/metrics/provider/librato/batcher.go
@@ -3,6 +3,7 @@ package librato
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"net/url"
@@ -42,7 +43,9 @@ func (p *Provider) batchMetrics(u *url.URL, interval time.Duration) ([]*http.Req
 	var user *url.Userinfo
 	user, u.User = u.User, nil
 
+	orig := u
 	u = u.ResolveReference(&url.URL{Path: batchMetricsPath})
+	u.RawQuery = orig.RawQuery
 
 	nextEnd := func(e int) int {
 		e += p.batchSize

--- a/go-kit/metrics/provider/librato/batcher.go
+++ b/go-kit/metrics/provider/librato/batcher.go
@@ -42,9 +42,7 @@ func (p *Provider) batchMetrics(u *url.URL, interval time.Duration) ([]*http.Req
 	var user *url.Userinfo
 	user, u.User = u.User, nil
 
-	orig := u
-	u = u.ResolveReference(&url.URL{Path: batchMetricsPath})
-	u.RawQuery = orig.RawQuery
+	u = u.ResolveReference(&url.URL{Path: batchMetricsPath, RawQuery: u.RawQuery})
 
 	nextEnd := func(e int) int {
 		e += p.batchSize

--- a/go-kit/metrics/provider/librato/batcher.go
+++ b/go-kit/metrics/provider/librato/batcher.go
@@ -3,7 +3,6 @@ package librato
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"math"
 	"net/http"
 	"net/url"


### PR DESCRIPTION
[This document](https://salesforce.quip.com/TOdVAy7RPs4R#ANJACAaoKDw) describes using query parameters on Librato API and l2met URLs to control routing of metrics through an OpenTelemetry collector.

Unfortunately, `heroku/x/go-kit` currently removes query parameters from the Librato URL [here](https://github.com/heroku/x/blob/023c823c2229dd9af1acbd354c0ea7758768df40/go-kit/metrics/provider/librato/batcher.go#L45). You can see a `go-playground` demonstration of the problem [here](https://play.golang.org/p/OzGHe1RkvVj).

This pull request copies `RawQuery` from the original URL to the new URL, to preserve query parameters.

Reference: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000BiXTYA0/view