### PR TITLE
Give more control over the scanner to the enduser

### DIFF
--- a/logplex/encoding/parser.go
+++ b/logplex/encoding/parser.go
@@ -8,40 +8,51 @@ import (
 	"github.com/pkg/errors"
 )
 
-func syslogParser() bufio.SplitFunc {
-	// format:
-	//nolint:lll
-	// 64 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 99\n65 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 100\n
-	// ^ frame size                                                       ^ boundary
+// SyslogSplitFunc splits the data based on the defined length prefix.
+// format:
+//nolint:lll
+// 64 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 99\n65 <190>1 2019-07-20T17:50:10.879238Z shuttle token shuttle - - 100\n
+// ^ frame size                                                       ^ boundary
+func SyslogSplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	// first space gives us the frame size
+	sp := bytes.IndexByte(data, ' ')
+	if sp == -1 {
+		if atEOF && len(data) > 0 {
+			return 0, nil, errors.Wrap(ErrBadFrame, "missing frame length")
+		}
+		return 0, nil, nil
+	}
+
+	if sp == 0 {
+		return 0, nil, errors.Wrap(ErrBadFrame, "invalid frame length")
+	}
+
+	msgSize, err := strconv.ParseUint(string(data[0:sp]), 10, 64)
+	if err != nil {
+		return 0, nil, errors.Wrap(ErrBadFrame, "couldnt parse frame length")
+	}
+
+	// 1 here is the 'space' itself, used in the framing above
+	dataBoundary := sp + int(msgSize) + 1
+
+	if dataBoundary > len(data) {
+		if atEOF {
+			return 0, nil, errors.Wrapf(ErrBadFrame, "message boundary (%d) not respected length (%d)", dataBoundary, len(data))
+		}
+		return 0, nil, nil
+	}
+
+	return dataBoundary, data[sp+1 : dataBoundary], nil
+}
+
+// TruncatingSyslogSplitFunc enforces a maximum line length after parsing.
+func TruncatingSyslogSplitFunc(maxLength int) bufio.SplitFunc {
 	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
-		// first space gives us the frame size
-		sp := bytes.IndexByte(data, ' ')
-		if sp == -1 {
-			if atEOF && len(data) > 0 {
-				return 0, nil, errors.Wrap(ErrBadFrame, "missing frame length")
-			}
-			return 0, nil, nil
+		advance, token, err = SyslogSplitFunc(data, atEOF)
+		if len(token) > maxLength {
+			token = token[0:maxLength]
 		}
 
-		if sp == 0 {
-			return 0, nil, errors.Wrap(ErrBadFrame, "invalid frame length")
-		}
-
-		msgSize, err := strconv.ParseUint(string(data[0:sp]), 10, 64)
-		if err != nil {
-			return 0, nil, errors.Wrap(ErrBadFrame, "couldnt parse frame length")
-		}
-
-		// 1 here is the 'space' itself, used in the framing above
-		dataBoundary := sp + int(msgSize) + 1
-
-		if dataBoundary > len(data) {
-			if atEOF {
-				return 0, nil, errors.Wrap(ErrBadFrame, "message boundary not respected")
-			}
-			return 0, nil, nil
-		}
-
-		return dataBoundary, data[sp+1 : dataBoundary], nil
+		return
 	}
 }


### PR DESCRIPTION
## Context

The `hermes` router will emit the `path` as part of the router log lines. This field is unbounded causing the entire logline to be unbounded. Typically, on the platform where log-shuttle is used, it will wrap loglines at the 10k boundary mark. We have put `hermes` into hard maintenance mode and are not planning to release any changes to `hermes`.

These additional config options will allow customization in `logfwd` to handle these longer log lines in a handful of ways.

## Description of Changes

- Added option functions to control Buffer and Split on the scanner.
- Added a truncating parser.

## Meta
- [Page](https://heroku.slack.com/archives/CCKDFGTL7/p1623918657158900)
- [Incident 2292](https://heroku.slack.com/archives/C025R2PV5H7/p1623928500000200)
- [SOX](https://heroku.slack.com/archives/C01D8TPMKPB/p1623946428183300)