### PR TITLE
Add utils for setting up lambda handlers

### DIFF
--- a/cmdutil/metrics/otel/otel.go
+++ b/cmdutil/metrics/otel/otel.go
@@ -38,9 +38,7 @@ func MustProvider(ctx context.Context, logger logrus.FieldLogger, cfg Config, se
 		otel.WithServiceInstanceIDAttribute(serviceInstanceID),
 		otel.WithStageAttribute(stage),
 	}
-	for _, opt := range opts {
-		allOpts = append(allOpts, opt)
-	}
+	allOpts = append(allOpts, opts...)
 
 	otelProvider, err := otel.New(ctx, service, allOpts...)
 	if err != nil {

--- a/go-kit/metrics/l2met/l2met.go
+++ b/go-kit/metrics/l2met/l2met.go
@@ -125,4 +125,4 @@ func (p *Provider) log() {
 func (p *Provider) Stop() {}
 
 // Flush implements Provider.
-func (p *Provider) Flush() {}
+func (p *Provider) Flush() error { return nil }

--- a/go-kit/metrics/l2met/l2met.go
+++ b/go-kit/metrics/l2met/l2met.go
@@ -123,3 +123,6 @@ func (p *Provider) log() {
 
 // Stop implements Provider.
 func (p *Provider) Stop() {}
+
+// Flush implements Provider.
+func (p *Provider) Flush() {}

--- a/go-kit/metrics/multiprovider/multiprovider.go
+++ b/go-kit/metrics/multiprovider/multiprovider.go
@@ -2,8 +2,11 @@
 package multiprovider
 
 import (
+	"strings"
+
 	kitmetrics "github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/multi"
+	"github.com/pkg/errors"
 
 	"github.com/heroku/x/go-kit/metrics"
 )
@@ -69,10 +72,22 @@ func (m *multiProvider) Stop() {
 }
 
 // Flush calls flush on all the underlying providers.
-func (m *multiProvider) Flush() {
+func (m *multiProvider) Flush() error {
+	errMsgs := []string{}
 	for _, p := range m.providers {
-		p.Flush()
+		err := p.Flush()
+		if err != nil {
+			// Don't immediately return the error.
+			// Record error msg and continue trying to
+			// flush to other providers.
+			errMsgs = append(errMsgs, err.Error())
+		}
 	}
+	if len(errMsgs) == 0 {
+		return nil
+	}
+
+	return errors.Errorf("flush failed for at least one provider: %s", strings.Join(errMsgs, ";"))
 }
 
 type multiCardinalityCounter []metrics.CardinalityCounter

--- a/go-kit/metrics/multiprovider/multiprovider.go
+++ b/go-kit/metrics/multiprovider/multiprovider.go
@@ -75,8 +75,7 @@ func (m *multiProvider) Stop() {
 func (m *multiProvider) Flush() error {
 	errMsgs := []string{}
 	for _, p := range m.providers {
-		err := p.Flush()
-		if err != nil {
+		if err := p.Flush(); err != nil {
 			// Don't immediately return the error.
 			// Record error msg and continue trying to
 			// flush to other providers.

--- a/go-kit/metrics/multiprovider/multiprovider.go
+++ b/go-kit/metrics/multiprovider/multiprovider.go
@@ -68,6 +68,13 @@ func (m *multiProvider) Stop() {
 	}
 }
 
+// Flush calls flush on all the underlying providers.
+func (m *multiProvider) Flush() {
+	for _, p := range m.providers {
+		p.Flush()
+	}
+}
+
 type multiCardinalityCounter []metrics.CardinalityCounter
 
 func (cc multiCardinalityCounter) With(labelValues ...string) metrics.CardinalityCounter {

--- a/go-kit/metrics/provider.go
+++ b/go-kit/metrics/provider.go
@@ -29,5 +29,5 @@ type Provider interface {
 	NewHistogram(name string, buckets int) metrics.Histogram
 	NewCardinalityCounter(name string) CardinalityCounter
 	Stop()
-	Flush()
+	Flush() error
 }

--- a/go-kit/metrics/provider.go
+++ b/go-kit/metrics/provider.go
@@ -29,4 +29,5 @@ type Provider interface {
 	NewHistogram(name string, buckets int) metrics.Histogram
 	NewCardinalityCounter(name string) CardinalityCounter
 	Stop()
+	Flush()
 }

--- a/go-kit/metrics/provider/discard/discard.go
+++ b/go-kit/metrics/provider/discard/discard.go
@@ -42,6 +42,9 @@ func (discardProvider) NewCardinalityCounter(string) xmetrics.CardinalityCounter
 // Stop implements Provider.
 func (discardProvider) Stop() {}
 
+// Flush implements Provider.
+func (discardProvider) Flush() {}
+
 type discardCardinalityCounter struct{}
 
 // With implements CardinalityCounter.

--- a/go-kit/metrics/provider/discard/discard.go
+++ b/go-kit/metrics/provider/discard/discard.go
@@ -43,7 +43,7 @@ func (discardProvider) NewCardinalityCounter(string) xmetrics.CardinalityCounter
 func (discardProvider) Stop() {}
 
 // Flush implements Provider.
-func (discardProvider) Flush() {}
+func (discardProvider) Flush() error { return nil }
 
 type discardCardinalityCounter struct{}
 

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -181,6 +181,7 @@ func New(u *url.URL, interval time.Duration, opts ...OptionFunc) xmetrics.Provid
 		errorHandler:     defaultErrorHandler,
 		done:             make(chan struct{}),
 		stopped:          make(chan struct{}),
+		flush:            make(chan chan struct{}),
 		percentilePrefix: DefaultPercentilePrefix,
 		numRetries:       DefaultNumRetries,
 		batchSize:        DefaultBatchSize,

--- a/go-kit/metrics/provider/librato/librato.go
+++ b/go-kit/metrics/provider/librato/librato.go
@@ -240,10 +240,11 @@ func (p *Provider) Stop() {
 // Flush flushes the buffer of locally recorded
 // metrics that have yet to be reported.
 // The func returns once reporting is complete.
-func (p *Provider) Flush() {
+func (p *Provider) Flush() error {
 	fl := make(chan struct{})
 	p.flush <- fl
 	<-fl
+	return nil
 }
 
 func prefixName(prefix, name string) string {

--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -134,10 +134,13 @@ func (p *Provider) Stop() {
 	_ = p.exporter.Shutdown(p.ctx)
 }
 
-// Flush calls Collect() on the provider's controller.
-// This is a no-op if Start() has been called on the provider.
-func (p *Provider) Flush() {
-	_ = p.controller.Collect(p.ctx)
+// Flush stops and starts the provider in order to flush metrics
+// immediately, without having to wait until the next collection occurs.
+// The flush is synchronous and returns an error if the provider cannot
+// restart after stopping.
+func (p *Provider) Flush() error {
+	p.Stop()
+	return p.Start()
 }
 
 // Meter returns an oltp meter used for the creation of metric instruments.

--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -133,13 +133,18 @@ func (p *Provider) Stop() {
 	_ = p.exporter.Shutdown(p.ctx)
 }
 
-// Flush stops and starts the provider in order to flush metrics
+// Flush stops and starts the controller in order to flush metrics
 // immediately, without having to wait until the next collection occurs.
-// The flush is synchronous and returns an error if the provider cannot
-// restart after stopping.
+// The flush is synchronous and returns an error if the controller fails to
+// flush or cannot restart after flushing.
 func (p *Provider) Flush() error {
-	p.Stop()
-	return p.Start()
+	if err := p.controller.Stop(p.ctx); err != nil {
+		return err
+	}
+	if err := p.controller.Start(p.ctx); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Meter returns an oltp meter used for the creation of metric instruments.

--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -113,7 +113,6 @@ type controller interface {
 	MeterProvider() metric.MeterProvider
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
-	Collect(ctx context.Context) error
 }
 
 // Start starts the provider's controller and exporter.

--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -113,6 +113,7 @@ type controller interface {
 	MeterProvider() metric.MeterProvider
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
+	Collect(ctx context.Context) error
 }
 
 // Start starts the provider's controller and exporter.
@@ -131,6 +132,12 @@ func (p *Provider) Start() error {
 func (p *Provider) Stop() {
 	_ = p.controller.Stop(p.ctx)
 	_ = p.exporter.Shutdown(p.ctx)
+}
+
+// Flush calls Collect() on the provider's controller.
+// This is a no-op if Start() has been called on the provider.
+func (p *Provider) Flush() {
+	_ = p.controller.Collect(p.ctx)
 }
 
 // Meter returns an oltp meter used for the creation of metric instruments.

--- a/go-kit/metrics/testmetrics/provider.go
+++ b/go-kit/metrics/testmetrics/provider.go
@@ -43,6 +43,9 @@ func (p *Provider) Stop() {
 	p.stopped = true
 }
 
+// Flush makes it Provider compliant.
+func (p *Provider) Flush() {}
+
 // NewCounter implements go-kit's Provider interface.
 func (p *Provider) NewCounter(name string) metrics.Counter {
 	return p.newCounter(name)

--- a/go-kit/metrics/testmetrics/provider.go
+++ b/go-kit/metrics/testmetrics/provider.go
@@ -44,7 +44,7 @@ func (p *Provider) Stop() {
 }
 
 // Flush makes it Provider compliant.
-func (p *Provider) Flush() {}
+func (p *Provider) Flush() error { return nil }
 
 // NewCounter implements go-kit's Provider interface.
 func (p *Provider) NewCounter(name string) metrics.Counter {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e
+	github.com/aws/aws-lambda-go v1.26.0 // indirect
 	github.com/aws/aws-sdk-go v1.13.10
 	github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e
-	github.com/aws/aws-lambda-go v1.26.0 // indirect
+	github.com/aws/aws-lambda-go v1.27.0
 	github.com/aws/aws-sdk-go v1.13.10
 	github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e h1:h0gP0hBU6DsA5IQduhLWGOEfIUKzJS5hhXQBSgHuF/g=
 github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
+github.com/aws/aws-lambda-go v1.26.0 h1:6ujqBpYF7tdZcBvPIccs98SpeGfrt/UOVEiexfNIdHA=
+github.com/aws/aws-lambda-go v1.26.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
 github.com/aws/aws-sdk-go v1.13.10 h1:tvcbplK9Z3loAz1Zlala0yFZxAHu7VCh1OzlPTOSUew=
 github.com/aws/aws-sdk-go v1.13.10/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228 h1:6rB1A80KrH56CUeQMp1a4fzEw44N8Jum9rs1Fihv2tA=

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e h1:h0gP0hBU6DsA5IQduhLWGOEfIUKzJS5hhXQBSgHuF/g=
 github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
-github.com/aws/aws-lambda-go v1.26.0 h1:6ujqBpYF7tdZcBvPIccs98SpeGfrt/UOVEiexfNIdHA=
-github.com/aws/aws-lambda-go v1.26.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
+github.com/aws/aws-lambda-go v1.27.0 h1:aLzrJwdyHoF1A18YeVdJjX8Ixkd+bpogdxVInvHcWjM=
+github.com/aws/aws-lambda-go v1.27.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
 github.com/aws/aws-sdk-go v1.13.10 h1:tvcbplK9Z3loAz1Zlala0yFZxAHu7VCh1OzlPTOSUew=
 github.com/aws/aws-sdk-go v1.13.10/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228 h1:6rB1A80KrH56CUeQMp1a4fzEw44N8Jum9rs1Fihv2tA=
@@ -31,6 +31,8 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codegangsta/negroni v1.0.0 h1:+aYywywx4bnKXWvoWtRfJ91vC59NbEhEY03sZjQhbVY=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -157,7 +159,9 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rollbar/rollbar-go v1.0.2/go.mod h1:AcFs5f0I+c71bpHlXNNDbOWJiKwjFDtISeXco0L5PKQ=
 github.com/rollbar/rollbar-go v1.2.0 h1:CUanFtVu0sa3QZ/fBlgevdGQGLWaE3D4HxoVSQohDfo=
 github.com/rollbar/rollbar-go v1.2.0/go.mod h1:czC86b8U4xdUH7W2C6gomi2jutLm8qK0OtrF5WMvpcc=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil/v3 v3.21.9/go.mod h1:YWp/H8Qs5fVmf17v7JNZzA0mPJ+mS2e9JdiUF9LlKzQ=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -178,6 +182,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
@@ -186,6 +191,7 @@ github.com/unrolled/secure v1.0.1 h1:PZ79/VmnyIrDWRAUp9lWSwmckdf8H0v9djiqZxAb8Tc
 github.com/unrolled/secure v1.0.1/go.mod h1:R6rugAuzh4TQpbFAq69oqZggyBQxFRFQIewtz5z7Jsc=
 github.com/urfave/cli v1.21.0 h1:wYSSj06510qPIzGSua9ZqsncMmWE3Zr55KBERygyrxE=
 github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
+github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -366,6 +372,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -7,6 +7,7 @@ import (
 	"github.com/joeshaw/envdecode"
 	"github.com/oklog/run"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/heroku/x/cmdutil"
 	"github.com/heroku/x/cmdutil/metrics"
@@ -16,6 +17,12 @@ import (
 	kitmetrics "github.com/heroku/x/go-kit/metrics"
 	"github.com/heroku/x/go-kit/metrics/l2met"
 	"github.com/heroku/x/go-kit/metrics/multiprovider"
+	xotel "github.com/heroku/x/go-kit/metrics/provider/otel"
+)
+
+const (
+	// This is the key for the "function" OTEL attribute. The value should be the function name.
+	functionKey = "function"
 )
 
 // Function defines configuration of a Lambda function.
@@ -68,10 +75,12 @@ func New(config interface{}) *Function {
 			context.Background(),
 			logger,
 			fc.Metrics.OTEL,
-			f.Name,
+			f.App,
 			f.Deploy,
 			f.Stage,
-			"lambda")
+			"lambda",
+			xotel.WithAttributes(attribute.String(functionKey, f.Name)),
+		)
 		metricsProviders = append(metricsProviders, otelProvider)
 	}
 

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -127,6 +127,12 @@ func (f *Function) Start(handler interface{}) {
 	awslambda.Start(handler)
 }
 
+// FlushMetrics is a hook for flushing metrics,
+// to ensure they are sent before the invocation context is torn down.
+func (f *Function) FlushMetrics() error {
+	return f.MetricsProvider.Flush()
+}
+
 type funcConfig struct {
 	Stage   string `env:"STAGE"`
 	Logger  svclog.Config

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -23,6 +23,9 @@ import (
 const (
 	// This is the key for the "function" OTEL attribute. The value should be the function name.
 	functionKey = "function"
+
+	// This is the key for the "stage" log field. The value should be "staging" or "production".
+	stageKey = "stage"
 )
 
 // Function defines configuration of a Lambda function.
@@ -53,11 +56,16 @@ func New(config interface{}) *Function {
 	}
 
 	logger := svclog.NewLogger(fc.Logger)
+	logger = logger.WithFields(logrus.Fields{
+		functionKey: fc.Name,
+		stageKey:    fc.Stage,
+	})
 
 	rollbar.Setup(logger, fc.Rollbar)
 
 	f := &Function{
-		Name:   fc.Logger.AppName,
+		App:    fc.Logger.AppName,
+		Name:   fc.Name,
 		Deploy: fc.Logger.Deploy,
 		Stage:  fc.Stage,
 		Logger: logger,
@@ -145,6 +153,7 @@ func (f *Function) FlushMetrics() error {
 }
 
 type funcConfig struct {
+	Name    string `env:"FUNCTION_NAME"`
 	Stage   string `env:"STAGE"`
 	Logger  svclog.Config
 	Metrics metrics.Config

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -20,7 +20,9 @@ import (
 
 // Function defines configuration of a Lambda function.
 type Function struct {
-	// Name of the function. This will be equivalent to the APP_NAME env var.
+	// App to which this function belongs. This will be equivalent to the APP_NAME env var.
+	App string
+	// Name of the function. This will be equivalent to the FUNCTION_NAME env var.
 	Name string
 	// Deploy is a cloud identifier.
 	Deploy string

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -1,0 +1,107 @@
+package lambda
+
+import (
+	awslambda "github.com/aws/aws-lambda-go/lambda"
+	"github.com/joeshaw/envdecode"
+	"github.com/oklog/run"
+	"github.com/sirupsen/logrus"
+
+	"github.com/heroku/x/cmdutil"
+	"github.com/heroku/x/cmdutil/metrics"
+	"github.com/heroku/x/cmdutil/rollbar"
+	"github.com/heroku/x/cmdutil/svclog"
+	xmetrics "github.com/heroku/x/go-kit/metrics"
+	"github.com/heroku/x/go-kit/metrics/l2met"
+)
+
+// Function defines configuration of a Lambda function.
+type Function struct {
+	// Name of the function. This will be equivalent to the APP_NAME env var.
+	Name string
+	// Deploy is a cloud identifier.
+	Deploy string
+	// Logger is a field logger.
+	Logger logrus.FieldLogger
+	// Metrics provider defines interactions for recording metrics.
+	MetricsProvider xmetrics.Provider
+
+	g run.Group
+}
+
+// New creates a new Function with a configured logger, rollbar agent and metrics provider.
+func New(config interface{}) *Function {
+	var fc funcConfig
+	envdecode.MustStrictDecode(&fc)
+
+	if config != nil {
+		envdecode.MustStrictDecode(config)
+	}
+
+	logger := svclog.NewLogger(fc.Logger)
+
+	rollbar.Setup(logger, fc.Rollbar)
+
+	f := &Function{
+		Name:   fc.Logger.AppName,
+		Deploy: fc.Logger.Deploy,
+		Logger: logger,
+	}
+
+	if fc.Metrics.Librato.User != "" {
+		f.MetricsProvider = metrics.StartLibrato(logger, fc.Metrics)
+	} else {
+		l2met := l2met.New(logger)
+		f.MetricsProvider = l2met
+		f.Add(cmdutil.NewContextServer(l2met.Run))
+	}
+
+	return f
+}
+
+// Add adds cmdutil.Servers to be run in the background.
+func (f *Function) Add(svs ...cmdutil.Server) {
+	for _, sv := range svs {
+		f.g.Add(sv.Run, sv.Stop)
+	}
+}
+
+/* Start takes a lambda handler that must satisfy one of the following signatures:
+ * 	func ()
+ * 	func () error
+ * 	func (TIn) error
+ * 	func () (TOut, error)
+ * 	func (TIn) (TOut, error)
+ * 	func (context.Context) error
+ * 	func (context.Context, TIn) error
+ * 	func (context.Context) (TOut, error)
+ * 	func (context.Context, TIn) (TOut, error)
+ *
+ * Where "TIn" and "TOut" are types compatible with the "encoding/json" standard library.
+ * See https://golang.org/pkg/encoding/json/#Unmarshal for how deserialization behaves.
+ *
+ * See https://github.com/aws/aws-lambda-go/blob/main/lambda/entry.go for more info.
+ */
+func (f *Function) Start(handler interface{}) {
+	defer f.MetricsProvider.Stop()
+
+	// Run logger, rollbar agent and metrics provider in the background.
+	go func() {
+		defer rollbar.ReportPanic(f.Logger)
+
+		// Run any background servers, if configured.
+		// For example, the l2met agent.
+		err := f.g.Run()
+
+		if err != nil {
+			f.Logger.WithError(err).Error("background server ended in error")
+		}
+	}()
+
+	awslambda.Start(handler)
+}
+
+type funcConfig struct {
+	Logger  svclog.Config
+	Metrics metrics.Config
+	Rollbar rollbar.Config
+}

--- a/lambda/function_test.go
+++ b/lambda/function_test.go
@@ -1,0 +1,30 @@
+package lambda
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNew_Function(t *testing.T) {
+	setupStandardConfig(t)
+
+	f := New(nil)
+
+	if f.Logger == nil {
+		t.Fatal("logger not configured")
+	}
+
+	if f.MetricsProvider == nil {
+		t.Fatal("metrics provider not configured")
+	}
+}
+
+func setupStandardConfig(t *testing.T) {
+	os.Setenv("APP_NAME", "test-app")
+	os.Setenv("DEPLOY", "test")
+
+	t.Cleanup(func() {
+		os.Unsetenv("APP_NAME")
+		os.Unsetenv("DEPLOY")
+	})
+}

--- a/lambda/function_test.go
+++ b/lambda/function_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestNew_Function(t *testing.T) {
-	setupStandardConfig(t)
+func TestNew_Func(t *testing.T) {
+	setupFuncConfig(t)
 
 	f := New(nil)
 
@@ -19,7 +19,7 @@ func TestNew_Function(t *testing.T) {
 	}
 }
 
-func setupStandardConfig(t *testing.T) {
+func setupFuncConfig(t *testing.T) {
 	os.Setenv("APP_NAME", "test-app")
 	os.Setenv("DEPLOY", "test")
 

--- a/lambda/function_test.go
+++ b/lambda/function_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestNew_Func(t *testing.T) {
+func TestNew_Function(t *testing.T) {
 	setupFuncConfig(t)
 
 	f := New(nil)


### PR DESCRIPTION
This addition includes a utility package that can be used to standardize the configuration and handler set-up of our Lambda functions. It is modeled off of the `cmdutil.Service` type.

The go-kit `metrics.Provider` interface has been extended to include a `Flush()` method that operates much the same as `Stop()`, but does not tear down the provider and may be called multiple times. In some cases, `Flush()` is a no-op. It has been added here so that recorded metric values may be optionally flushed to the provider service from within the handler. This has proved necessary when using the Librato & OTEL providers, to ensure data are not lost when the execution context of the Lambda invocation is torn down.