### PR TITLE
Add support for Heroku Redis 6 using TLS

### DIFF
--- a/cmdutil/redispool/redispool.go
+++ b/cmdutil/redispool/redispool.go
@@ -70,7 +70,10 @@ func (c Config) Pools() ([]*redis.Pool, error) {
 func newPool(cfg Config) *redis.Pool {
 	return &redis.Pool{
 		Dial: func() (redis.Conn, error) {
-			conn, err := redis.DialURL(cfg.URL)
+			// For Heroku Redis we need to skip the TLS verification, see
+			// https://devcenter.heroku.com/articles/heroku-redis#connecting-in-go
+			// redis.DialTLSSkipVerify will have no effect for non-TLS connections.
+			conn, err := redis.DialURL(cfg.URL, redis.DialTLSSkipVerify(true))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Connect to any Heroku Redis plan using Redis 6 (default) require TLS (see https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance).

This commit follows the directions outlined in [Connecting to Go](https://devcenter.heroku.com/articles/heroku-redis#connecting-in-go) to allow for both TLS and non-TLS connections.