### PR TITLE
adds ability to choose the hash used for sharding

### DIFF
--- a/sharder/sharder_test.go
+++ b/sharder/sharder_test.go
@@ -3,8 +3,9 @@ package sharder_test
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/heroku/x/sharder"
+
+	"github.com/google/uuid"
 )
 
 type TestHasher struct {

--- a/sharder/sharder_test.go
+++ b/sharder/sharder_test.go
@@ -1,10 +1,19 @@
-package sharder
+package sharder_test
 
 import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/heroku/x/sharder"
 )
+
+type TestHasher struct {
+	expected uint32
+}
+
+func (f *TestHasher) Hash(key string) uint32 {
+	return f.expected
+}
 
 func TestSharder(t *testing.T) {
 	t.Run("constructing with bad count panics", func(t *testing.T) {
@@ -14,11 +23,41 @@ func TestSharder(t *testing.T) {
 			}
 		}()
 
-		New(0)
+		sharder.New(0)
 	})
 
-	t.Run("only one shard", func(t *testing.T) {
-		s := New(1)
+	t.Run("custom hasher", func(t *testing.T) {
+		// fix the test so that all inputs return 7
+		f := &TestHasher{expected: 1337}
+		s := sharder.New(10, sharder.WithHasher(f))
+
+		for i := 0; i < 100; i++ {
+			if idx := s.Index(uuid.New().String()); idx != 7 {
+				t.Fatalf("want index 0, got %d", idx)
+			}
+		}
+	})
+
+	t.Run("only one shard, default hasher", func(t *testing.T) {
+		s := sharder.New(1)
+		for i := 0; i < 100; i++ {
+			if idx := s.Index(uuid.New().String()); idx != 0 {
+				t.Fatalf("want index 0, got %d", idx)
+			}
+		}
+	})
+
+	t.Run("only one shard, locking hasher", func(t *testing.T) {
+		s := sharder.New(1, sharder.WithLockingHasher())
+		for i := 0; i < 100; i++ {
+			if idx := s.Index(uuid.New().String()); idx != 0 {
+				t.Fatalf("want index 0, got %d", idx)
+			}
+		}
+	})
+
+	t.Run("only one shard, lock free hasher", func(t *testing.T) {
+		s := sharder.New(1, sharder.WithLockFreeHasher())
 		for i := 0; i < 100; i++ {
 			if idx := s.Index(uuid.New().String()); idx != 0 {
 				t.Fatalf("want index 0, got %d", idx)
@@ -27,10 +66,24 @@ func TestSharder(t *testing.T) {
 	})
 
 	t.Run("many shards", func(t *testing.T) {
-		s := New(10)
+
+		locking := sharder.New(10, sharder.WithLockingHasher())
+		lockFree := sharder.New(10, sharder.WithLockFreeHasher())
 		for i := 0; i < 100; i++ {
-			if idx := s.Index(uuid.New().String()); idx < 0 || idx >= 10 {
-				t.Fatalf("want index in range 0..10, got %d", idx)
+			uuid := uuid.New().String()
+			lockingIdx := locking.Index(uuid)
+			freeIdx := lockFree.Index(uuid)
+
+			if lockingIdx < 0 || lockingIdx >= 10 {
+				t.Fatalf("want locking index in range 0..10, got %d", lockingIdx)
+			}
+
+			if freeIdx < 0 || freeIdx >= 10 {
+				t.Fatalf("want lock free index in range 0..10, got %d", freeIdx)
+			}
+
+			if lockingIdx != freeIdx {
+				t.Fatalf("want locking index equal to lock free index, got %d == %d", lockingIdx, freeIdx)
 			}
 		}
 	})

--- a/sharder/sharder_test.go
+++ b/sharder/sharder_test.go
@@ -15,6 +15,7 @@ func (f *TestHasher) Hash(key string) uint32 {
 	return f.expected
 }
 
+//nolint:gocyclo // This is a test, there are going to be lots of if statements
 func TestSharder(t *testing.T) {
 	t.Run("constructing with bad count panics", func(t *testing.T) {
 		defer func() {


### PR DESCRIPTION
This change adds complete control over the hashing algorithm used by the
Sharder. Sometimes a user may want to tightly control allocations, other
times a user may just want pure concurrency.

The existing behavior remains unchanged so that existing users of the
library are not surprised. This existing behavior is now wrapped as the
`WithLockingHasher` option.

A second option, `WithLockFreeHasher` is available that uses the
same fnv hashing algorithm without the use of locks.

A third option, `WithHasher`, allows for complete customization.