### PR TITLE
Collect OTEL metric data once a min

### DIFF
--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/generic"
@@ -42,6 +43,9 @@ const (
 
 	// The value of the "cloud" attribute should be the cloud (e.g. "heroku.com")
 	cloudKey = "cloud"
+
+	// The default collection interval.
+	defaultCollectPeriod = time.Minute
 )
 
 // Provider initializes a global otlp meter provider that can collect metrics and
@@ -96,6 +100,7 @@ func New(ctx context.Context, serviceName string, opts ...Option) (xmetrics.Prov
 		processor.New(p.aggregator, p.exporter),
 		metriccontroller.WithExporter(p.exporter),
 		metriccontroller.WithResource(p.serviceNameResource),
+		metriccontroller.WithCollectPeriod(defaultCollectPeriod),
 	)
 	global.SetMeterProvider(p.controller.MeterProvider())
 


### PR DESCRIPTION
## Reasons for making these changes

Some of our alerting for our Runtime services will rely on percentage-based metrics computed using other simple metrics. Each percentage-based metric is computed over a single event, so numbers can fluctuate widely when the underlying metrics are `undefined`. Collecting the metrics at a lower frequency (less often) will ensure more of the underlying metrics are defined on the events, making the derived column value more accurate and meaningful. 

## Description of changes

- Hard-code the `CollectPeriod` to be `1m` on the OTEL controller.