### PR TITLE
Pass collector URL by value

### DIFF
--- a/cmdutil/metrics/otel/otel.go
+++ b/cmdutil/metrics/otel/otel.go
@@ -19,7 +19,11 @@ func MustProvider(ctx context.Context, logger logrus.FieldLogger, cfg Config, se
 	// This provider is used for metrics reporting to the  collector.
 	logger.WithField("metrics_destinations", strings.Join(cfg.MetricsDestinations, ",")).Info("setting up  provider")
 
-	client := otel.NewHTTPClient(cfg.CollectorURL)
+	if cfg.CollectorURL == nil {
+		logger.Fatal("provider collectorURL cannot be nil")
+	}
+
+	client := otel.NewHTTPClient(*cfg.CollectorURL)
 	expOpts := otlpmetric.WithMetricExportKindSelector(metric.DeltaExportKindSelector())
 	exporter := otlpmetric.NewUnstarted(client, expOpts)
 

--- a/go-kit/metrics/provider/otel/client.go
+++ b/go-kit/metrics/provider/otel/client.go
@@ -11,12 +11,13 @@ import (
 )
 
 // NewHTTPClient creates a new HTTP client for exporting otel metrics.
-func NewHTTPClient(url *url.URL, opts ...otlpmetrichttp.Option) otlpmetric.Client {
+func NewHTTPClient(url url.URL, opts ...otlpmetrichttp.Option) otlpmetric.Client {
 	userInfo := url.User
 	authHeader := make(map[string]string)
 	authHeader["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(userInfo.String()))
 
 	// Ensure there's no cred in the URL.
+	// Can only do this because the URL is specified by value.
 	url.User = nil
 
 	defaultOpts := []otlpmetrichttp.Option{


### PR DESCRIPTION
[Buzz](https://github.com/heroku/buzz) needs to be able to configure multiple providers multiple times as a part of its operational approach. The existing code works the first time a provider is initiated, but if it is attempted a second time, it fails. 

The `collectorURL` is passed in by reference, and the code inside the method mutates the URL; no bueno. This change passes the URL by value, so the mutation has no base side effects.