### PR TITLE
Fix otel.NewCardinalityCounter

### DIFF
--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -317,7 +317,7 @@ func (h *Histogram) Observe(value float64) {
 
 // NewCardinalityCounter implements metrics.Provider.
 func (p *Provider) NewCardinalityCounter(name string) xmetrics.CardinalityCounter {
-	return &xmetrics.HLLCounter{}
+	return xmetrics.NewHLLCounter(name)
 }
 
 func prefixName(prefix, name string) string {

--- a/go-kit/metrics/provider/otel/provider_test.go
+++ b/go-kit/metrics/provider/otel/provider_test.go
@@ -1,0 +1,19 @@
+package otel
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewCardinalityCounter_InsertDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("The code did panic")
+		}
+	}()
+
+	p, _ := New(context.Background(), "my-service")
+	c := p.NewCardinalityCounter("my-counter")
+
+	c.Insert([]byte("hey"))
+}


### PR DESCRIPTION
The `otel.NewCardinalityCounter` method returns
`&xmetrics.HLLCounter{}`, which means `HLLCounter.counter` is `nil`,
which will prevent code from calling `.Insert()` on it without panicing.

Use the `NewHLLCounter` method insead, it correctly initializes the
`counter` field.