### PR TITLE
[WIP] Use `HistogramDistribution` as default aggregator

### DIFF
--- a/cmdutil/metrics/otel/config.go
+++ b/cmdutil/metrics/otel/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	Enabled             bool     `env:"ENABLE_OTEL_COLLECTION"`
 	CollectorURL        *url.URL `env:"OTEL_COLLECTOR_URL"`
+	UseExactAggregator  bool     `env:"OTEL_USE_EXACT_AGGREGATOR"`
 	MetricsDestinations []string `env:"OTEL_METRICS_DESTINATIONS,default=honeycomb;argus"`
 	Honeycomb           honeycomb.Config
 }

--- a/cmdutil/metrics/otel/config.go
+++ b/cmdutil/metrics/otel/config.go
@@ -9,9 +9,9 @@ import (
 // Config is a reusable configuration struct that contains the necessary
 // environment variables to setup an metrics.Provider
 type Config struct {
-	Enabled             bool     `env:"ENABLE_OTEL_COLLECTION"`
-	CollectorURL        *url.URL `env:"OTEL_COLLECTOR_URL"`
-	UseExactAggregator  bool     `env:"OTEL_USE_EXACT_AGGREGATOR"`
 	MetricsDestinations []string `env:"OTEL_METRICS_DESTINATIONS,default=honeycomb;argus"`
 	Honeycomb           honeycomb.Config
+	CollectorURL        *url.URL `env:"OTEL_COLLECTOR_URL"`
+	Enabled             bool     `env:"ENABLE_OTEL_COLLECTION"`
+	UseExactAggregator  bool     `env:"OTEL_USE_EXACT_AGGREGATOR"`
 }

--- a/cmdutil/metrics/otel/otel.go
+++ b/cmdutil/metrics/otel/otel.go
@@ -35,7 +35,13 @@ func MustProvider(ctx context.Context, logger logrus.FieldLogger, cfg Config, se
 		attrs = append(attrs, attribute.String(md, "true"))
 	}
 
+	aggrOpt := otel.WithDefaultAggregator()
+	if cfg.UseExactAggregator {
+		aggrOpt = otel.WithExactAggregator()
+	}
+
 	allOpts := []otel.Option{
+		aggrOpt,
 		otel.WithExporter(exporter),
 		otel.WithAttributes(attrs...),
 		otel.WithServiceNamespaceAttribute(serviceNamespace),

--- a/go-kit/metrics/provider/otel/options.go
+++ b/go-kit/metrics/provider/otel/options.go
@@ -30,6 +30,13 @@ type Option func(*Provider) error
 
 // WithDefaultAggregator initializes the Provider with a default aggregator.
 func WithDefaultAggregator() Option {
+	return WithAggregator(simple.NewWithHistogramDistribution())
+}
+
+// WithExactAggregator initializes the Provider with the ExactDistribution aggregator.
+//
+// Note: simple.NewWithExactDistribution is removed in go.opentelemetry.io/otel/sdk/metric@v0.26.0.
+func WithExactAggregator() Option {
 	return WithAggregator(simple.NewWithExactDistribution())
 }
 


### PR DESCRIPTION
The are two problems with the existing `ExactDistribution` aggregator:

1. It's gone in go.opentelemetry.io/otel/sdk/metric@v0.26.0/
2. It ships every metrics ever collected causing huge payloads for busy
   services.

This commit resolves that by switching the HistogramDistribution, which
will send much smaller payloads. It is most similar to the original
histogram implementation found in https://pkg.go.dev/github.com/heroku/x@v0.0.47/go-kit/metrics/provider/librato#Histogram.

## Checklists

- [ ] Find way to adjust histogram buckets