### PR TITLE
add new highcardmetrics pkg to grpcmetrics

### DIFF
--- a/grpc/grpcmetrics/highcardmetrics/server.go
+++ b/grpc/grpcmetrics/highcardmetrics/server.go
@@ -158,5 +158,5 @@ func isCanceled(err error) bool {
 }
 
 func ms(d time.Duration) float64 {
-	return float64(d) / float64(time.Millisecond)
+	return float64(d.Milliseconds())
 }

--- a/grpc/grpcmetrics/highcardmetrics/server.go
+++ b/grpc/grpcmetrics/highcardmetrics/server.go
@@ -75,7 +75,7 @@ type serverStream struct {
 	explicitHistograms bool
 }
 
-//// RecvMsg implements the grpc.Stream interface.
+// RecvMsg implements the grpc.Stream interface.
 func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	defer func(begin time.Time) {
 		instrumentStreamSend(ss.reg, ss.explicitHistograms, ss.labels, time.Since(begin), err)
@@ -84,7 +84,7 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	return ss.ServerStream.SendMsg(m)
 }
 
-//// RecvMsg implements the grpc.Stream interface.
+// RecvMsg implements the grpc.Stream interface.
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 	defer func(begin time.Time) {
 		instrumentStreamRecv(ss.reg, ss.explicitHistograms, ss.labels, time.Since(begin), err)

--- a/grpc/grpcmetrics/highcardmetrics/server.go
+++ b/grpc/grpcmetrics/highcardmetrics/server.go
@@ -1,0 +1,162 @@
+package highcardmetrics
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/heroku/x/go-kit/metrics"
+	"github.com/heroku/x/go-kit/metricsregistry"
+	"github.com/heroku/x/grpc/grpcmetrics"
+)
+
+// NewUnaryServerInterceptor returns an interceptor for unary server calls
+// which will report metrics to the given provider.
+func NewUnaryServerInterceptor(p metrics.Provider) grpc.UnaryServerInterceptor {
+	r0 := metricsregistry.New(p)
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (_ interface{}, err error) {
+		r1 := metricsregistry.NewPrefixed(r0, "grpc.server")
+
+		defer func(begin time.Time) {
+			service, method := parseFullMethod(info.FullMethod)
+			labels := []string{"service", service, "method", method, "response-status", code(err)}
+
+			instrumentMethod(r1, labels, time.Since(begin))
+		}(time.Now())
+
+		return handler(ctx, req)
+	}
+}
+
+// NewStreamServerInterceptor returns an interceptor for stream server calls
+// which will report metrics to the given provider.
+func NewStreamServerInterceptor(p metrics.Provider) grpc.StreamServerInterceptor {
+	r0 := metricsregistry.New(p)
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		r1 := metricsregistry.NewPrefixed(r0, "grpc.server")
+
+		service, method := parseFullMethod(info.FullMethod)
+
+		labels := []string{"service", service, "method", method}
+
+		clients := r1.GetOrRegisterGauge("stream.clients").With(labels...)
+		clients.Add(1)
+
+		defer func(begin time.Time) {
+			clients.Add(-1)
+
+			labels = append(labels, "response-status", code(err))
+
+			instrumentMethod(r1, labels, time.Since(begin))
+		}(time.Now())
+
+		wrapped := &serverStream{r1, ss, labels}
+		return handler(srv, wrapped)
+	}
+}
+
+// serverStream provides a light wrapper over grpc.ServerStream
+// to instrument SendMsg and RecvMsg.
+type serverStream struct {
+	reg metricsregistry.Registry
+	grpc.ServerStream
+	labels []string
+}
+
+//// RecvMsg implements the grpc.Stream interface.
+func (ss *serverStream) SendMsg(m interface{}) (err error) {
+	defer func(begin time.Time) {
+		instrumentStreamSend(ss.reg, ss.labels, time.Since(begin), err)
+	}(time.Now())
+
+	return ss.ServerStream.SendMsg(m)
+}
+
+//// RecvMsg implements the grpc.Stream interface.
+func (ss *serverStream) RecvMsg(m interface{}) (err error) {
+	defer func(begin time.Time) {
+		instrumentStreamRecv(ss.reg, ss.labels, time.Since(begin), err)
+	}(time.Now())
+
+	return ss.ServerStream.RecvMsg(m)
+}
+
+func instrumentMethod(r metricsregistry.Registry, labels []string, duration time.Duration) {
+	r.GetOrRegisterHistogram("request-duration.ms", 50).With(labels...).Observe(ms(duration))
+	r.GetOrRegisterCounter("requests").With(labels...).Add(1)
+}
+
+func instrumentStreamSend(r metricsregistry.Registry, labels []string, duration time.Duration, err error) {
+	r.GetOrRegisterHistogram("stream.send-duration.ms", 50).With(labels...).Observe(ms(duration))
+	r.GetOrRegisterCounter("stream.sends").With(labels...).Add(1)
+
+	if err != nil && !isCanceled(err) {
+		r.GetOrRegisterCounter("stream.sends.errors").Add(1)
+	}
+}
+
+func instrumentStreamRecv(r metricsregistry.Registry, labels []string, duration time.Duration, err error) {
+	r.GetOrRegisterHistogram("stream.recv-duration.ms", 50).With(labels...).Observe(ms(duration))
+	r.GetOrRegisterCounter("stream.recvs").With(labels...).Add(1)
+
+	if err != nil && !isCanceled(err) {
+		r.GetOrRegisterCounter("stream.recvs.errors").With(labels...).Add(1)
+	}
+}
+
+func parseFullMethod(fullMethod string) (string, string) {
+	parts := strings.Split(fullMethod, "/")
+	if len(parts) < 3 {
+		return grpcmetrics.Unknown, grpcmetrics.Unknown
+	}
+
+	fullService := parts[1]
+	method := parts[2]
+
+	sp := strings.Split(fullService, ".")
+	service := sp[len(sp)-1]
+
+	return dasherize(service), dasherize(method)
+}
+
+// code returns the gRPC error code, handling context and unknown errors.
+func code(err error) string {
+	if err == context.Canceled {
+		return grpcmetrics.Canceled
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		return grpcmetrics.Unknown
+	}
+
+	return dasherize(st.Code().String())
+}
+
+var uppers = regexp.MustCompile(`([[:lower:]])([[:upper:]])`)
+
+func dasherize(s string) string {
+	return strings.ToLower(uppers.ReplaceAllString(s, "$1-$2"))
+}
+
+// isCanceled returns true if error is a context or gRPC cancelation error.
+func isCanceled(err error) bool {
+	if err == context.Canceled {
+		return true
+	}
+
+	if st, ok := status.FromError(err); ok {
+		return st.Code() == codes.Canceled
+	}
+
+	return false
+}
+
+func ms(d time.Duration) float64 {
+	return float64(d) / float64(time.Millisecond)
+}

--- a/grpc/grpcmetrics/highcardmetrics/server_test.go
+++ b/grpc/grpcmetrics/highcardmetrics/server_test.go
@@ -40,13 +40,13 @@ func TestUnaryServerInterceptor(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 
-	p.CheckCounter("grpc.server.requests", 1, "service", "hello", "method", "ping", "response-status", "ok")
-	p.CheckCounter("grpc.server.requests", 1, "service", "hello", "method", "ping", "response-status", "canceled")
-	p.CheckCounter("grpc.server.requests", 1, "service", "hello", "method", "ping", "response-status", "unknown")
+	p.CheckCounter("grpc.server.requests", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "ok")
+	p.CheckCounter("grpc.server.requests", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "canceled")
+	p.CheckCounter("grpc.server.requests", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "unknown")
 
-	p.CheckObservationCount("grpc.server.request-duration.ms", 1, "service", "hello", "method", "ping", "response-status", "ok")
-	p.CheckObservationCount("grpc.server.request-duration.ms", 1, "service", "hello", "method", "ping", "response-status", "canceled")
-	p.CheckObservationCount("grpc.server.request-duration.ms", 1, "service", "hello", "method", "ping", "response-status", "unknown")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "ok")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "canceled")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "unknown")
 }
 
 func TestStreamServerInterceptor(t *testing.T) {
@@ -78,7 +78,7 @@ func TestStreamServerInterceptor(t *testing.T) {
 	}
 
 	err = ssi(nil, &testServerStream{}, info, func(srv interface{}, stream grpc.ServerStream) error {
-		p.CheckGauge("grpc.server.stream.clients", 1, "service", "hello", "method", "stream-updates")
+		p.CheckGauge("grpc.server.stream.clients", 1, serviceKey, "hello", methodKey, "stream-updates")
 		return nil
 	})
 	if err != nil {
@@ -90,18 +90,18 @@ func TestStreamServerInterceptor(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 
-	p.CheckCounter("grpc.server.requests", 2, "service", "hello", "method", "stream-updates", "response-status", "ok")
-	p.CheckCounter("grpc.server.requests", 1, "service", "hello", "method", "stream-updates", "response-status", "unknown")
-	p.CheckObservationCount("grpc.server.request-duration.ms", 2, "service", "hello", "method", "stream-updates", "response-status", "ok")
-	p.CheckObservationCount("grpc.server.request-duration.ms", 1, "service", "hello", "method", "stream-updates", "response-status", "unknown")
+	p.CheckCounter("grpc.server.requests", 2, serviceKey, "hello", methodKey, "stream-updates", responseStatusKey, "ok")
+	p.CheckCounter("grpc.server.requests", 1, serviceKey, "hello", methodKey, "stream-updates", responseStatusKey, "unknown")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 2, serviceKey, "hello", methodKey, "stream-updates", responseStatusKey, "ok")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "stream-updates", responseStatusKey, "unknown")
 
-	p.CheckGauge("grpc.server.stream.clients", 0, "service", "hello", "method", "stream-updates")
+	p.CheckGauge("grpc.server.stream.clients", 0, serviceKey, "hello", methodKey, "stream-updates")
 
-	p.CheckCounter("grpc.server.stream.sends", 2, "service", "hello", "method", "stream-updates")
-	p.CheckObservationCount("grpc.server.stream.send-duration.ms", 2, "service", "hello", "method", "stream-updates")
+	p.CheckCounter("grpc.server.stream.sends", 2, serviceKey, "hello", methodKey, "stream-updates")
+	p.CheckObservationCount("grpc.server.stream.send-duration.ms", 2, serviceKey, "hello", methodKey, "stream-updates")
 
-	p.CheckCounter("grpc.server.stream.recvs", 1, "service", "hello", "method", "stream-updates")
-	p.CheckObservationCount("grpc.server.stream.recv-duration.ms", 1, "service", "hello", "method", "stream-updates")
+	p.CheckCounter("grpc.server.stream.recvs", 1, serviceKey, "hello", methodKey, "stream-updates")
+	p.CheckObservationCount("grpc.server.stream.recv-duration.ms", 1, serviceKey, "hello", methodKey, "stream-updates")
 }
 
 type testServerStream struct {

--- a/grpc/grpcmetrics/highcardmetrics/server_test.go
+++ b/grpc/grpcmetrics/highcardmetrics/server_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUnaryServerInterceptor(t *testing.T) {
 	p := testmetrics.NewProvider(t)
-	usi := NewUnaryServerInterceptor(p)
+	usi := NewUnaryServerInterceptor(p, false)
 	handler := func(resp interface{}, err error) grpc.UnaryHandler {
 		return func(ctx context.Context, req interface{}) (interface{}, error) {
 			return resp, err
@@ -51,7 +51,7 @@ func TestUnaryServerInterceptor(t *testing.T) {
 
 func TestStreamServerInterceptor(t *testing.T) {
 	p := testmetrics.NewProvider(t)
-	ssi := NewStreamServerInterceptor(p)
+	ssi := NewStreamServerInterceptor(p, false)
 	handler := func(err error) grpc.StreamHandler {
 		return func(srv interface{}, stream grpc.ServerStream) error {
 			if err == nil {

--- a/grpc/grpcmetrics/highcardmetrics/server_test.go
+++ b/grpc/grpcmetrics/highcardmetrics/server_test.go
@@ -7,12 +7,17 @@ import (
 
 	"google.golang.org/grpc"
 
+	kitmetrics "github.com/go-kit/kit/metrics"
+
+	"github.com/heroku/x/go-kit/metrics"
 	"github.com/heroku/x/go-kit/metrics/testmetrics"
 )
 
+var _ metrics.Provider = (*mockProvider)(nil)
+
 func TestUnaryServerInterceptor(t *testing.T) {
-	p := testmetrics.NewProvider(t)
-	usi := NewUnaryServerInterceptor(p, false)
+	p := mockProvider{Provider: testmetrics.NewProvider(t)}
+	usi := NewUnaryServerInterceptor(&p, false)
 	handler := func(resp interface{}, err error) grpc.UnaryHandler {
 		return func(ctx context.Context, req interface{}) (interface{}, error) {
 			return resp, err
@@ -47,11 +52,19 @@ func TestUnaryServerInterceptor(t *testing.T) {
 	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "ok")
 	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "canceled")
 	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "unknown")
+
+	if p.histogramCount != 1 {
+		t.Fatalf("want %d regular histograms, got %d", 1, p.histogramCount)
+	}
+
+	if p.explicitHistogramCount != 0 {
+		t.Fatalf("want %d explicit histograms, got %d", 1, p.explicitHistogramCount)
+	}
 }
 
 func TestStreamServerInterceptor(t *testing.T) {
-	p := testmetrics.NewProvider(t)
-	ssi := NewStreamServerInterceptor(p, false)
+	p := mockProvider{Provider: testmetrics.NewProvider(t)}
+	ssi := NewStreamServerInterceptor(&p, false)
 	handler := func(err error) grpc.StreamHandler {
 		return func(srv interface{}, stream grpc.ServerStream) error {
 			if err == nil {
@@ -102,6 +115,137 @@ func TestStreamServerInterceptor(t *testing.T) {
 
 	p.CheckCounter("grpc.server.stream.recvs", 1, serviceKey, "hello", methodKey, "stream-updates")
 	p.CheckObservationCount("grpc.server.stream.recv-duration.ms", 1, serviceKey, "hello", methodKey, "stream-updates")
+
+	if p.histogramCount != 3 {
+		t.Fatalf("want %d regular histograms, got %d", 1, p.histogramCount)
+	}
+
+	if p.explicitHistogramCount != 0 {
+		t.Fatalf("want %d explicit histograms, got %d", 1, p.explicitHistogramCount)
+	}
+}
+
+func TestUnaryServerWithExplicitHistogramsInterceptor(t *testing.T) {
+	p := mockProvider{Provider: testmetrics.NewProvider(t)}
+
+	usi := NewUnaryServerInterceptor(&p, true)
+	handler := func(resp interface{}, err error) grpc.UnaryHandler {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			return resp, err
+		}
+	}
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/spec.Hello/Ping",
+	}
+
+	resp, err := usi(context.Background(), "ping", info, handler("pong", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != "pong" {
+		t.Fatalf("resp = %v, want %q", resp, "pong")
+	}
+
+	_, err = usi(context.Background(), "ping", info, handler(nil, errors.New("test")))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	_, err = usi(context.Background(), "ping", info, handler(nil, context.Canceled))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	p.CheckCounter("grpc.server.requests", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "ok")
+	p.CheckCounter("grpc.server.requests", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "canceled")
+	p.CheckCounter("grpc.server.requests", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "unknown")
+
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "ok")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "canceled")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "ping", responseStatusKey, "unknown")
+
+	if p.histogramCount != 0 {
+		t.Fatalf("want %d regular histograms, got %d", 1, p.histogramCount)
+	}
+
+	if p.explicitHistogramCount != 1 {
+		t.Fatalf("want %d explicit histograms, got %d", 1, p.explicitHistogramCount)
+	}
+}
+
+func (p *mockProvider) NewExplicitHistogram(name string, fn metrics.DistributionFunc) kitmetrics.Histogram {
+	p.explicitHistogramCount++
+
+	return p.Provider.NewExplicitHistogram(name, fn)
+}
+
+func (p *mockProvider) NewHistogram(name string, buckets int) kitmetrics.Histogram {
+	p.histogramCount++
+
+	return p.Provider.NewHistogram(name, buckets)
+}
+
+func TestStreamServerWithExplicitHistogramsInterceptor(t *testing.T) {
+	p := mockProvider{Provider: testmetrics.NewProvider(t)}
+	ssi := NewStreamServerInterceptor(&p, true)
+	handler := func(err error) grpc.StreamHandler {
+		return func(srv interface{}, stream grpc.ServerStream) error {
+			if err == nil {
+				if err := stream.SendMsg("ping"); err != nil {
+					t.Fatal("unexpected error", err)
+				}
+				if err := stream.RecvMsg("pong"); err != nil {
+					t.Fatal("unexpected error", err)
+				}
+				if err := stream.SendMsg("ping"); err != nil {
+					t.Fatal("unexpected error", err)
+				}
+			}
+			return err
+		}
+	}
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/spec.Hello/StreamUpdates",
+	}
+
+	err := ssi(nil, &testServerStream{}, info, handler(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ssi(nil, &testServerStream{}, info, func(srv interface{}, stream grpc.ServerStream) error {
+		p.CheckGauge("grpc.server.stream.clients", 1, serviceKey, "hello", methodKey, "stream-updates")
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ssi(nil, &testServerStream{}, info, handler(errors.New("test")))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	p.CheckCounter("grpc.server.requests", 2, serviceKey, "hello", methodKey, "stream-updates", responseStatusKey, "ok")
+	p.CheckCounter("grpc.server.requests", 1, serviceKey, "hello", methodKey, "stream-updates", responseStatusKey, "unknown")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 2, serviceKey, "hello", methodKey, "stream-updates", responseStatusKey, "ok")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, serviceKey, "hello", methodKey, "stream-updates", responseStatusKey, "unknown")
+
+	p.CheckGauge("grpc.server.stream.clients", 0, serviceKey, "hello", methodKey, "stream-updates")
+
+	p.CheckCounter("grpc.server.stream.sends", 2, serviceKey, "hello", methodKey, "stream-updates")
+	p.CheckObservationCount("grpc.server.stream.send-duration.ms", 2, serviceKey, "hello", methodKey, "stream-updates")
+
+	p.CheckCounter("grpc.server.stream.recvs", 1, serviceKey, "hello", methodKey, "stream-updates")
+	p.CheckObservationCount("grpc.server.stream.recv-duration.ms", 1, serviceKey, "hello", methodKey, "stream-updates")
+
+	if p.histogramCount != 0 {
+		t.Fatalf("want %d regular histograms, got %d", 1, p.histogramCount)
+	}
+
+	if p.explicitHistogramCount != 3 {
+		t.Fatalf("want %d explicit histograms, got %d", 1, p.explicitHistogramCount)
+	}
 }
 
 type testServerStream struct {
@@ -114,4 +258,10 @@ func (*testServerStream) SendMsg(m interface{}) error {
 
 func (*testServerStream) RecvMsg(m interface{}) error {
 	return nil
+}
+
+type mockProvider struct {
+	*testmetrics.Provider
+	histogramCount         int
+	explicitHistogramCount int
 }

--- a/grpc/grpcmetrics/highcardmetrics/server_test.go
+++ b/grpc/grpcmetrics/highcardmetrics/server_test.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/heroku/x/go-kit/metrics/testmetrics"
 	"google.golang.org/grpc"
+
+	"github.com/heroku/x/go-kit/metrics/testmetrics"
 )
 
 func TestUnaryServerInterceptor(t *testing.T) {

--- a/grpc/grpcmetrics/highcardmetrics/server_test.go
+++ b/grpc/grpcmetrics/highcardmetrics/server_test.go
@@ -1,0 +1,116 @@
+package highcardmetrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/heroku/x/go-kit/metrics/testmetrics"
+	"google.golang.org/grpc"
+)
+
+func TestUnaryServerInterceptor(t *testing.T) {
+	p := testmetrics.NewProvider(t)
+	usi := NewUnaryServerInterceptor(p)
+	handler := func(resp interface{}, err error) grpc.UnaryHandler {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			return resp, err
+		}
+	}
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/spec.Hello/Ping",
+	}
+
+	resp, err := usi(context.Background(), "ping", info, handler("pong", nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != "pong" {
+		t.Fatalf("resp = %v, want %q", resp, "pong")
+	}
+
+	_, err = usi(context.Background(), "ping", info, handler(nil, errors.New("test")))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	_, err = usi(context.Background(), "ping", info, handler(nil, context.Canceled))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	p.CheckCounter("grpc.server.requests", 1, "service", "hello", "method", "ping", "response-status", "ok")
+	p.CheckCounter("grpc.server.requests", 1, "service", "hello", "method", "ping", "response-status", "canceled")
+	p.CheckCounter("grpc.server.requests", 1, "service", "hello", "method", "ping", "response-status", "unknown")
+
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, "service", "hello", "method", "ping", "response-status", "ok")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, "service", "hello", "method", "ping", "response-status", "canceled")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, "service", "hello", "method", "ping", "response-status", "unknown")
+}
+
+func TestStreamServerInterceptor(t *testing.T) {
+	p := testmetrics.NewProvider(t)
+	ssi := NewStreamServerInterceptor(p)
+	handler := func(err error) grpc.StreamHandler {
+		return func(srv interface{}, stream grpc.ServerStream) error {
+			if err == nil {
+				if err := stream.SendMsg("ping"); err != nil {
+					t.Fatal("unexpected error", err)
+				}
+				if err := stream.RecvMsg("pong"); err != nil {
+					t.Fatal("unexpected error", err)
+				}
+				if err := stream.SendMsg("ping"); err != nil {
+					t.Fatal("unexpected error", err)
+				}
+			}
+			return err
+		}
+	}
+	info := &grpc.StreamServerInfo{
+		FullMethod: "/spec.Hello/StreamUpdates",
+	}
+
+	err := ssi(nil, &testServerStream{}, info, handler(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ssi(nil, &testServerStream{}, info, func(srv interface{}, stream grpc.ServerStream) error {
+		p.CheckGauge("grpc.server.stream.clients", 1, "service", "hello", "method", "stream-updates")
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ssi(nil, &testServerStream{}, info, handler(errors.New("test")))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	p.CheckCounter("grpc.server.requests", 2, "service", "hello", "method", "stream-updates", "response-status", "ok")
+	p.CheckCounter("grpc.server.requests", 1, "service", "hello", "method", "stream-updates", "response-status", "unknown")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 2, "service", "hello", "method", "stream-updates", "response-status", "ok")
+	p.CheckObservationCount("grpc.server.request-duration.ms", 1, "service", "hello", "method", "stream-updates", "response-status", "unknown")
+
+	p.CheckGauge("grpc.server.stream.clients", 0, "service", "hello", "method", "stream-updates")
+
+	p.CheckCounter("grpc.server.stream.sends", 2, "service", "hello", "method", "stream-updates")
+	p.CheckObservationCount("grpc.server.stream.send-duration.ms", 2, "service", "hello", "method", "stream-updates")
+
+	p.CheckCounter("grpc.server.stream.recvs", 1, "service", "hello", "method", "stream-updates")
+	p.CheckObservationCount("grpc.server.stream.recv-duration.ms", 1, "service", "hello", "method", "stream-updates")
+}
+
+type testServerStream struct {
+	grpc.ServerStream
+}
+
+func (*testServerStream) SendMsg(m interface{}) error {
+	return nil
+}
+
+func (*testServerStream) RecvMsg(m interface{}) error {
+	return nil
+}


### PR DESCRIPTION
## Context

We want to add two new options to the grpc server, which allows us to collect metrics using attributes. 

The new `highcardmetrics` pkg provides high cardinality unary and stream server interceptors. The interceptors take an `explicit` bool arg, which makes the histogram type configurable. Passing in `true` will create explicit histograms with a default 5s distribution. 

## Usage

To initialize a grpc server with high cardinality unary and stream servers using explicit histograms:

```go
gSrv, hSrv := grpcserver.NewStandardH2C(
  apiSrv,
  // high cardinality interceptors using explicit histograms
  grpcserver.HighCardInterceptors(
     highcardmetrics.NewUnaryServerInterceptor(o.metricsProvider, true), 
     highcardmetrics.NewStreamServerInterceptor(o.metricsProvider, true),
   ),
)
```