### PR TITLE
go-kit: fix gauge bug in otel provider

### DIFF
--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -271,7 +271,7 @@ func (g *Gauge) Set(value float64) {
 
 // Add implements metrics.Gauge.
 func (g *Gauge) Add(delta float64) {
-	g.Gauge.Set(delta)
+	g.Gauge.Add(delta)
 }
 
 // Histogram is a histogram.


### PR DESCRIPTION
## Context

The call to otel provider's `gauge.Add()` erroneously calls `gauge.Set()`. 

This PR fixes the bug, by calling `gauge.Add()`. 

