### PR TITLE
Use consistent Go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  golang: heroku/golang@0.1.2
+  golang: heroku/golang@0.4.0
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,6 @@ workflows:
   ci:
     jobs:
       - golang/golangci-lint:
-          version: "v1.28.1"
+          version: "v1.31.0"
       - golang/test-nodb:
-          version: "1.14"
+          version: "1.15"

--- a/cmdutil/spaceca/spaceca.go
+++ b/cmdutil/spaceca/spaceca.go
@@ -32,6 +32,7 @@ func NewServerTLSConfig(domain string, secData map[string][]byte) (*tls.Config, 
 		return nil, errors.Wrap(err, "error generating TLS cert")
 	}
 
+	//nolint:gosec,G40 // we define a minimum version via `tlsconfig.Modern`
 	config := &tls.Config{
 		Certificates: []tls.Certificate{*cert},
 	}

--- a/go-kit/metrics/provider/librato/librato_test.go
+++ b/go-kit/metrics/provider/librato/librato_test.go
@@ -4,6 +4,7 @@
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
+//nolint:gosec,G404 // we use numeric values for testing
 package librato
 
 import (

--- a/hmetrics/example/advanced/main.go
+++ b/hmetrics/example/advanced/main.go
@@ -41,6 +41,6 @@ func main() {
 		port = "8080"
 	}
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 }

--- a/hmetrics/examples_test.go
+++ b/hmetrics/examples_test.go
@@ -63,6 +63,6 @@ func ExampleReport_advanced() {
 		port = "8080"
 	}
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 }


### PR DESCRIPTION
The go.mod file in this repository specifies that we're relying on Go 1.15 yet the CircleCI configuration used older versions.

This uses Go 1.15 for test runs and for linting (by upgrading to the [golangci/golangci-lint@v1.31.0](https://github.com/golangci/golangci-lint/releases/tag/v1.31.0) release).

A couple changes were made to satisfy the later version of `golangci-lint`.