### PR TITLE
Support dyno ID verification

### DIFF
--- a/dynoid/dynoid.go
+++ b/dynoid/dynoid.go
@@ -1,0 +1,96 @@
+package dynoid
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+)
+
+type IssuerCallback func(string) error
+
+type Verifier struct {
+	IssuerCallback IssuerCallback
+	config         *oidc.Config
+	providers      sync.Map
+}
+
+func New(clientID string) *Verifier {
+	return &Verifier{config: &oidc.Config{ClientID: clientID}}
+}
+
+func AllowHerokuHost(host string) IssuerCallback {
+	return func(issuer string) error {
+		if !strings.HasPrefix(issuer, fmt.Sprintf("https://oidc.%v/", host)) {
+			return fmt.Errorf("untrusted issuer: %v", issuer)
+		}
+
+		return nil
+	}
+}
+
+func (v *Verifier) Verify(ctx context.Context, rawIDToken string) (*oidc.IDToken, error) {
+	issuer, err := parseIssuer(rawIDToken)
+	if err != nil {
+		return nil, err
+	}
+
+	if v.IssuerCallback == nil {
+		return nil, fmt.Errorf("must check issuer")
+	}
+	if err = v.IssuerCallback(issuer); err != nil {
+		return nil, err
+	}
+
+	provider, err := v.provider(ctx, issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	verifier := provider.Verifier(v.config)
+
+	return verifier.Verify(ctx, rawIDToken)
+}
+
+func (v *Verifier) provider(ctx context.Context, issuer string) (*oidc.Provider, error) {
+	provider, ok := v.providers.Load(issuer)
+	if ok {
+		return provider.(*oidc.Provider), nil
+	}
+
+	p, err := oidc.NewProvider(ctx, issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	provider, _ = v.providers.LoadOrStore(issuer, p)
+
+	return provider.(*oidc.Provider), nil
+}
+
+func parseIssuer(p string) (string, error) {
+	parts := strings.Split(p, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("malformed token: expected 3 parts got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("unable to decode token: %w", err)
+	}
+
+	v := struct {
+		Issuer string `json:"iss"`
+	}{}
+
+	err = json.Unmarshal(payload, &v)
+	if err != nil {
+		return "", fmt.Errorf("unable to unmarshal token: %w", err)
+	}
+
+	return v.Issuer, nil
+}

--- a/dynoid/dynoid_test.go
+++ b/dynoid/dynoid_test.go
@@ -1,0 +1,33 @@
+package dynoid
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+
+	"github.com/heroku/x/dynoid/dynoidtest"
+)
+
+func TestVerification(t *testing.T) {
+	iss, err := dynoidtest.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := iss.GenerateIDToken("heroku")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	ctx = oidc.ClientContext(ctx, iss.HTTPClient())
+
+	verifier := New("heroku")
+	verifier.IssuerCallback = AllowHerokuHost("heroku.local")
+
+	_, err = verifier.Verify(ctx, token)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/dynoid/dynoidtest/dynoidtest.go
+++ b/dynoid/dynoidtest/dynoidtest.go
@@ -1,0 +1,101 @@
+package dynoidtest
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/golang-jwt/jwt/v4"
+	jose "gopkg.in/square/go-jose.v2"
+)
+
+type Issuer struct {
+	key *rsa.PrivateKey
+}
+
+func New() (*Issuer, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Issuer{key: key}, nil
+}
+
+func (iss *Issuer) GenerateIDToken(clientID string) (string, error) {
+	now := time.Now()
+
+	claims := &jwt.RegisteredClaims{
+		Audience:  jwt.ClaimStrings([]string{"heroku"}),
+		ExpiresAt: jwt.NewNumericDate(now.Add(5 * time.Minute)),
+		IssuedAt:  jwt.NewNumericDate(now),
+		Issuer:    "https://oidc.heroku.local/issuers/test",
+		Subject:   "app:00000000-0000-0000-0000-000000000001.sushi::dyno:web.1",
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "primary"
+
+	return token.SignedString(iss.key)
+}
+
+func (iss *Issuer) HTTPClient() *http.Client {
+	return &http.Client{Transport: &roundTripper{issuer: iss}}
+}
+
+type roundTripper struct {
+	issuer  *Issuer
+	once    sync.Once
+	handler http.Handler
+}
+
+func (rt *roundTripper) init() {
+	r := chi.NewRouter()
+
+	r.Get("/issuers/test/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		header := w.Header()
+		header.Set("Content-Type", "application/json")
+
+		w.WriteHeader(http.StatusOK)
+
+		_, _ = w.Write([]byte(`{` +
+			`"issuer":"https://oidc.heroku.local/issuers/test",` +
+			`"authorization_endpoint":"/dummy/authorization",` +
+			`"jwks_uri":"https://oidc.heroku.local/issuers/test/.well-known/jwks.json",` +
+			`"response_types_supported":["implicit"],` +
+			`"grant_types_supported":["implicit"],` +
+			`"subject_types_supported":["public"],` +
+			`"id_token_signing_alg_values_supported":["RS256"]` +
+			`}`))
+	})
+
+	r.Get("/issuers/test/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		jwks := &jose.JSONWebKeySet{}
+		jwks.Keys = append(jwks.Keys, jose.JSONWebKey{Key: rt.issuer.key.Public(), KeyID: "primary"})
+
+		header := w.Header()
+		header.Set("Content-Type", "application/jwk-set+json")
+
+		w.WriteHeader(http.StatusOK)
+
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(jwks)
+	})
+
+	rt.handler = r
+}
+
+func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.once.Do(rt.init)
+
+	rec := httptest.NewRecorder()
+
+	rt.handler.ServeHTTP(rec, req)
+
+	return rec.Result(), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,13 @@ require (
 	github.com/aws/aws-lambda-go v1.27.0
 	github.com/aws/aws-sdk-go v1.13.10
 	github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228
+	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-ini/ini v1.33.0 // indirect
 	github.com/go-kit/kit v0.9.0
 	github.com/gogo/protobuf v1.3.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/golang/protobuf v1.5.2
 	github.com/gomodule/redigo v1.8.1
 	github.com/google/gops v0.3.22
@@ -57,4 +59,5 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/caio/go-tdigest.v2 v2.3.0
 	gopkg.in/ini.v1 v1.42.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codegangsta/negroni v1.0.0 h1:+aYywywx4bnKXWvoWtRfJ91vC59NbEhEY03sZjQhbVY=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
+github.com/coreos/go-oidc/v3 v3.2.0 h1:2eR2MGR7thBXSQ2YbODlF0fcmgtliLCfr9iX6RW11fc=
+github.com/coreos/go-oidc/v3 v3.2.0/go.mod h1:rEJ/idjfUyfkBit1eI1fvyr+64/g9dcKpAm8MJMesvo=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -62,6 +64,8 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -256,6 +260,7 @@ golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200505041828-1ed23360d12c/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -367,6 +372,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/ini.v1 v1.42.0 h1:7N3gPTt50s8GuLortA00n8AqRTk75qOP98+mTPpgzRk=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
+gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This is a counterpart for heroku/dogwood#2762 et al. to support dyno ID verification in Go components.

It includes a package responsible for verification and another to ease testing of the functionality.