### PR TITLE
Quick enhancements to redispool and available histogram distributions

### DIFF
--- a/cmdutil/redispool/redispool.go
+++ b/cmdutil/redispool/redispool.go
@@ -3,6 +3,7 @@
 package redispool
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -69,11 +70,11 @@ func (c Config) Pools() ([]*redis.Pool, error) {
 
 func newPool(cfg Config) *redis.Pool {
 	return &redis.Pool{
-		Dial: func() (redis.Conn, error) {
+		DialContext: func(ctx context.Context) (redis.Conn, error) {
 			// For Heroku Redis we need to skip the TLS verification, see
 			// https://devcenter.heroku.com/articles/heroku-redis#connecting-in-go
 			// redis.DialTLSSkipVerify will have no effect for non-TLS connections.
-			conn, err := redis.DialURL(cfg.URL, redis.DialTLSSkipVerify(true))
+			conn, err := redis.DialURLContext(ctx, cfg.URL, redis.DialTLSSkipVerify(true))
 			if err != nil {
 				return nil, err
 			}

--- a/go-kit/metrics/distributions.go
+++ b/go-kit/metrics/distributions.go
@@ -8,6 +8,13 @@ var (
 	//     []float64{10, 55, 255, 505, 1255, 2505, 3755, 4505, 4755, 4955, 5000}
 	FiveSecondDistribution = WithStandardPercentiles(0, 5000)
 
+	// TenSecondDistribution is a percentile distribution between 0 and 10,000 milliseconds.
+	//
+	// Generated Distribution
+	//
+	//     []float64{20, 110, 510, 1010, 2510, 5010, 7510, 9010, 9510, 9910, 10000}
+	TenSecondDistribution = WithStandardPercentiles(0, 10000)
+
 	// ThirtySecondDistribution is a percentile distribution between 0 and 30,000 milliseconds.
 	//
 	// Generated Distribution

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/protobuf v1.5.2
-	github.com/gomodule/redigo v1.8.1
+	github.com/gomodule/redigo v1.8.9
 	github.com/google/gops v0.3.22
 	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/gomodule/redigo v1.8.1 h1:Abmo0bI7Xf0IhdIPc7HZQzZcShdnmxeoVuDDtIQp8N8=
-github.com/gomodule/redigo v1.8.1/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
+github.com/gomodule/redigo v1.8.9 h1:Sl3u+2BI/kk+VEatbj0scLdrFhjPmbxOc1myhDP41ws=
+github.com/gomodule/redigo v1.8.9/go.mod h1:7ArFNvsTjH8GMMzB4uy1snslv2BwmginuMs06a1uzZE=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
A couple of quick enhancements.

- Updated redigo dependency.
- Converted the `redispool` wrapper to use `DialContext` over `Dial` to allow for proper propagation of contexts that may have deadlines or otherwise be cancelled.
- Added a TenSecondDistribution to provide a middle between the 5s and 30s distributions for time based histograms.