### PR TITLE
Add low card provider for optionally skipping labels

### DIFF
--- a/go-kit/metrics/lowcard/low_cardinality.go
+++ b/go-kit/metrics/lowcard/low_cardinality.go
@@ -1,0 +1,120 @@
+package lowcard
+
+import (
+	"github.com/go-kit/kit/metrics"
+	xmetrics "github.com/heroku/x/go-kit/metrics"
+)
+
+// NewLowCardinalityWrappedProvider is a wrapper around metrics.Provider
+// that ignores any added labels via metric.With() call.
+func NewLowCardinalityWrappedProvider(p xmetrics.Provider, labels []string) xmetrics.Provider {
+	return lowCardinalityWrappedProvider{
+		Provider:        p,
+		labelsToInclude: labels,
+	}
+}
+
+type lowCardinalityWrappedProvider struct {
+	xmetrics.Provider
+	// Labels that will be added to instruments.
+	labelsToInclude []string
+}
+
+type counter struct {
+	metrics.Counter
+	// Labels that will be added to counters.
+	labelsToInclude []string
+}
+
+// NewCounter wraps counter around metrics.Counter.
+func (p lowCardinalityWrappedProvider) NewCounter(name string) metrics.Counter {
+	return counter{
+		Counter:         p.Provider.NewCounter(name),
+		labelsToInclude: p.labelsToInclude,
+	}
+}
+
+// With noops and returns counter if the passed labelValues
+// do not start with a label that has been designated for inclusion.
+func (c counter) With(labelValues ...string) metrics.Counter {
+	c.Counter = c.Counter.With(sanitizeLabels(c.labelsToInclude, labelValues)...)
+	return c
+}
+
+type gauge struct {
+	metrics.Gauge
+	// Labels that will be added to gauges.
+	labelsToInclude []string
+}
+
+// NewGauge wraps gauge around metrics.Gauge.
+func (p lowCardinalityWrappedProvider) NewGauge(name string) metrics.Gauge {
+	return gauge{
+		Gauge:           p.Provider.NewGauge(name),
+		labelsToInclude: p.labelsToInclude,
+	}
+}
+
+// With noops and returns gauge if the passed labelValues
+// do not start with a label that has been designated for inclusion.
+func (g gauge) With(labelValues ...string) metrics.Gauge {
+	g.Gauge = g.Gauge.With(sanitizeLabels(g.labelsToInclude, labelValues)...)
+	return g
+}
+
+type histogram struct {
+	metrics.Histogram
+	// Labels that will be added to histograms.
+	labelsToInclude []string
+}
+
+// With noops and returns histogram if the passed labelValues
+// do not start with a label that has been designated for inclusion.
+func (p lowCardinalityWrappedProvider) NewHistogram(name string, buckets int) metrics.Histogram {
+	return histogram{
+		Histogram:       p.Provider.NewHistogram(name, buckets),
+		labelsToInclude: p.labelsToInclude,
+	}
+}
+
+// With noops and returns histogram if the passed labelValues
+// do not start with a label that has been designated for inclusion.
+func (p lowCardinalityWrappedProvider) NewExplicitHistogram(name string, fn xmetrics.DistributionFunc) metrics.Histogram {
+	return histogram{
+		Histogram:       p.Provider.NewExplicitHistogram(name, fn),
+		labelsToInclude: p.labelsToInclude,
+	}
+}
+
+// With noops and returns histogram.
+func (h histogram) With(labelValues ...string) metrics.Histogram {
+	h.Histogram = h.Histogram.With(sanitizeLabels(h.labelsToInclude, labelValues)...)
+	return h
+}
+
+func sanitizeLabels(labelsToInclude, labelValues []string) []string {
+	sanitized := []string{}
+
+	// The instrument expects an even number of values
+	// since they represent key-value pairs. If there
+	// are not an even number, we assume labels are malformed.
+	// If malformed, the labels are not added.
+	if len(labelValues)%2 != 0 {
+		return []string{}
+	}
+	for i := 0; i <= len(labelValues)-2; i += 2 {
+		if contains(labelsToInclude, labelValues[i]) {
+			sanitized = append(sanitized, labelValues[i], labelValues[i+1])
+		}
+	}
+	return sanitized
+}
+
+func contains(strs []string, str string) bool {
+	for _, s := range strs {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/go-kit/metrics/lowcard/low_cardinality.go
+++ b/go-kit/metrics/lowcard/low_cardinality.go
@@ -2,6 +2,7 @@ package lowcard
 
 import (
 	"github.com/go-kit/kit/metrics"
+
 	xmetrics "github.com/heroku/x/go-kit/metrics"
 )
 

--- a/go-kit/metrics/lowcard/low_cardinality_test.go
+++ b/go-kit/metrics/lowcard/low_cardinality_test.go
@@ -1,0 +1,365 @@
+package lowcard
+
+import (
+	"fmt"
+	"testing"
+
+	xmetrics "github.com/heroku/x/go-kit/metrics"
+	"github.com/heroku/x/go-kit/metrics/testmetrics"
+)
+
+var (
+	testBaseName      = "i.am.a"
+	testCounterName   = fmt.Sprintf("%s.counter", testBaseName)
+	testGaugeName     = fmt.Sprintf("%s.gauge", testBaseName)
+	testHistogramName = fmt.Sprintf("%s.histogram", testBaseName)
+	testLabelName     = "label"
+)
+
+func TestWrappedProvider(t *testing.T) {
+	t.Run("counter label skipped", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{})
+		defer mp.Stop()
+
+		c := mp.NewCounter(testCounterName)
+		c.Add(1)
+
+		var labels []string
+
+		checkCounter(t, mp, testCounterName, 1, labels...)
+
+		c = c.With(testBaseName, testLabelName)
+		c.Add(1)
+
+		checkCounter(t, mp, testCounterName, 2, labels...)
+	})
+
+	t.Run("gauge label skipped", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{})
+		defer mp.Stop()
+
+		g := mp.NewGauge(testGaugeName)
+		g.Add(1)
+
+		var labels []string
+
+		checkGauge(t, mp, testGaugeName, 1, labels...)
+
+		g = g.With(testBaseName, testLabelName)
+		g.Add(1)
+
+		checkGauge(t, mp, testGaugeName, 2, labels...)
+	})
+
+	t.Run("histogram label skipped", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{})
+		defer mp.Stop()
+
+		g := mp.NewHistogram(testHistogramName, 50)
+		g.Observe(float64(1))
+
+		var labels []string
+		var obs = []float64{1}
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+
+		g = g.With(testBaseName, testLabelName)
+
+		g.Observe(float64(1))
+		obs = append(obs, float64(1))
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+	})
+
+	t.Run("explicit histogram label skipped", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{})
+		defer mp.Stop()
+
+		g := mp.NewExplicitHistogram(testHistogramName, xmetrics.TenSecondDistribution)
+		g.Observe(float64(1))
+
+		var labels []string
+		var obs = []float64{1}
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+
+		g = g.With(testBaseName, testLabelName)
+
+		g.Observe(float64(1))
+		obs = append(obs, float64(1))
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+	})
+
+	t.Run("counter label added", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		c := mp.NewCounter(testCounterName)
+		c.Add(1)
+
+		var labels []string
+
+		checkCounter(t, mp, testCounterName, 1, labels...)
+
+		labels = append(labels, testBaseName, testLabelName)
+		c = c.With(labels...)
+
+		c.Add(1)
+
+		checkCounter(t, mp, testCounterName, 1, labels...)
+	})
+
+	t.Run("gauge label added", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		g := mp.NewGauge(testGaugeName)
+		g.Add(1)
+
+		var labels []string
+
+		checkGauge(t, mp, testGaugeName, 1, labels...)
+
+		labels = append(labels, testBaseName, testLabelName)
+		g = g.With(labels...)
+
+		g.Add(1)
+
+		checkGauge(t, mp, testGaugeName, 1, labels...)
+	})
+
+	t.Run("histogram label added", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		h := mp.NewHistogram(testHistogramName, 50)
+		h.Observe(float64(1))
+
+		var labels []string
+		var obs = []float64{1}
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+
+		labels = append(labels, testBaseName, testLabelName)
+		h = h.With(labels...)
+
+		h.Observe(float64(1))
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+	})
+
+	t.Run("explicit histogram label added", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		h := mp.NewExplicitHistogram(testHistogramName, xmetrics.TenSecondDistribution)
+		h.Observe(float64(1))
+
+		var labels []string
+		var obs = []float64{1}
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+
+		labels = append(labels, testBaseName, testLabelName)
+		h = h.With(labels...)
+
+		h.Observe(float64(1))
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+	})
+
+	t.Run("multiple counter labels added", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		c := mp.NewCounter(testCounterName)
+		c.Add(1)
+
+		var labels []string
+
+		checkCounter(t, mp, testCounterName, 1, labels...)
+
+		labels = append(labels, testBaseName, testLabelName, testBaseName, testLabelName)
+		c = c.With(labels...)
+
+		c.Add(1)
+
+		checkCounter(t, mp, testCounterName, 1, labels...)
+	})
+
+	t.Run("multiple gauge labels added", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		g := mp.NewGauge(testGaugeName)
+		g.Add(1)
+
+		var labels []string
+
+		checkGauge(t, mp, testGaugeName, 1, labels...)
+
+		labels = append(labels, testBaseName, testLabelName, testBaseName, testLabelName)
+		g = g.With(labels...)
+
+		g.Add(1)
+
+		checkGauge(t, mp, testGaugeName, 1, labels...)
+	})
+
+	t.Run("multiple histogram labels added", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		h := mp.NewHistogram(testHistogramName, 50)
+		h.Observe(float64(1))
+
+		var labels []string
+		var obs = []float64{1}
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+
+		labels = append(labels, testBaseName, testLabelName, testBaseName, testLabelName)
+		h = h.With(labels...)
+
+		h.Observe(float64(1))
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+	})
+
+	t.Run("multiple explicit histogram labels added", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		h := mp.NewExplicitHistogram(testHistogramName, xmetrics.TenSecondDistribution)
+		h.Observe(float64(1))
+
+		var labels []string
+		var obs = []float64{1}
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+
+		labels = append(labels, testBaseName, testLabelName, testBaseName, testLabelName)
+		h = h.With(labels...)
+
+		h.Observe(float64(1))
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+	})
+
+	t.Run("malformed counter labels skipped", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		c := mp.NewCounter(testCounterName)
+		c.Add(1)
+
+		var labels []string
+
+		checkCounter(t, mp, testCounterName, 1, labels...)
+
+		// Odd number of entries. Malformed.
+		labels = append(labels, testBaseName, testLabelName, testBaseName, testLabelName, testBaseName)
+		c = c.With(labels...)
+
+		c.Add(1)
+
+		checkCounter(t, mp, testCounterName, 2)
+	})
+
+	t.Run("malformed gauge labels skipped", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		g := mp.NewGauge(testGaugeName)
+		g.Add(1)
+
+		var labels []string
+
+		checkGauge(t, mp, testGaugeName, 1, labels...)
+
+		// Odd number of entries. Malformed.
+		labels = append(labels, testBaseName, testLabelName, testBaseName, testLabelName, testBaseName)
+		g = g.With(labels...)
+
+		g.Add(1)
+
+		checkGauge(t, mp, testGaugeName, 2)
+	})
+
+	t.Run("malformed histogram labels skipped", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		h := mp.NewHistogram(testHistogramName, 50)
+		h.Observe(float64(1))
+
+		var labels []string
+		var obs = []float64{1}
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+
+		// Odd number of entries. Malformed.
+		labels = append(labels, testBaseName, testLabelName, testBaseName, testLabelName, testBaseName)
+		h = h.With(labels...)
+
+		h.Observe(float64(1))
+		obs = append(obs, float64(1))
+
+		checkHistogram(t, mp, testHistogramName, obs)
+	})
+
+	t.Run("malformed explicit histogram labels skipped", func(t *testing.T) {
+		mp := NewLowCardinalityWrappedProvider(testmetrics.NewProvider(t), []string{testBaseName})
+		defer mp.Stop()
+
+		h := mp.NewExplicitHistogram(testHistogramName, xmetrics.TenSecondDistribution)
+		h.Observe(float64(1))
+
+		var labels []string
+		var obs = []float64{1}
+
+		checkHistogram(t, mp, testHistogramName, obs, labels...)
+
+		// Odd number of entries. Malformed.
+		labels = append(labels, testBaseName, testLabelName, testBaseName, testLabelName, testBaseName)
+		h = h.With(labels...)
+
+		h.Observe(float64(1))
+		obs = append(obs, float64(1))
+
+		checkHistogram(t, mp, testHistogramName, obs)
+	})
+}
+
+//nolint:unparam
+func checkCounter(t *testing.T, mp xmetrics.Provider, name string, v float64, labelValues ...string) {
+	if lcp, ok := mp.(lowCardinalityWrappedProvider); ok {
+		if tp, ok := lcp.Provider.(*testmetrics.Provider); ok {
+			tp.CheckCounter(name, v, labelValues...)
+			return
+		}
+	}
+	t.Error("failed to check counter; could not cast to *testmetrics.Provider")
+}
+
+//nolint:unparam
+func checkGauge(t *testing.T, mp xmetrics.Provider, name string, v float64, labelValues ...string) {
+	if lcp, ok := mp.(lowCardinalityWrappedProvider); ok {
+		if tp, ok := lcp.Provider.(*testmetrics.Provider); ok {
+			tp.CheckGauge(name, v, labelValues...)
+			return
+		}
+	}
+	t.Error("failed to check gauge; could not cast to *testmetrics.Provider")
+}
+
+func checkHistogram(t *testing.T, mp xmetrics.Provider, name string, v []float64, labelValues ...string) {
+	if lcp, ok := mp.(lowCardinalityWrappedProvider); ok {
+		if tp, ok := lcp.Provider.(*testmetrics.Provider); ok {
+			tp.CheckObservations(name, v, labelValues...)
+			return
+		}
+	}
+	t.Error("failed to check histogram; could not cast to *testmetrics.Provider")
+}


### PR DESCRIPTION
This PR adds a `lowcard` package that may be used to wrap `metrics.Provider`s. 

Labels added to instruments using `With()` will be ignored unless explicitly marked for inclusion. Label inclusion is indicated by passing the list to `NewLowCardinalityWrappedProvider()` as an argument when creating the low card wrapper.