### PR TITLE
Add clock pkg for simple time abstractions

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,0 +1,17 @@
+package clock
+
+import "time"
+
+// Default is the default clock.
+var Default = Func(time.Now)
+
+// Clock tells you the current time.
+type Clock interface {
+	Now() time.Time
+}
+
+// Func is a function that returns a time.
+type Func func() time.Time
+
+// Now() ensures that Func satisfies the Clock interface.
+func (fn Func) Now() time.Time { return fn() }

--- a/clock/clocktest/clocktest.go
+++ b/clock/clocktest/clocktest.go
@@ -1,0 +1,36 @@
+package clocktest
+
+import (
+	"time"
+
+	"github.com/heroku/router/clock"
+)
+
+// New returns a test clock that will respond to
+// Now() calls using the times provided.
+func New(ts ...time.Time) clock.Clock {
+	return clock.Func(func() (t time.Time) {
+		if len(ts) == 0 {
+			return
+		}
+		if len(ts) == 1 {
+			t, ts = ts[0], ts[:0]
+			return
+		}
+
+		t, ts = ts[0], ts[1:]
+		return
+	})
+}
+
+// NewFromDurations returns a test clock that will respond to
+// Now() calls with times that are after the current time by
+// the passed durations.
+func NewFromDurations(ds ...time.Duration) clock.Clock {
+	t0 := time.Now()
+	ts := make([]time.Time, 0, len(ds))
+	for _, d := range ds {
+		ts = append(ts, t0.Add(d))
+	}
+	return New(ts...)
+}


### PR DESCRIPTION
The `clock` pkg provides useful abstraction around Go's std time telling/measuring package.

Instead of direct calls to `time.Now()`, you would construct a struct with a `clock.Clock` field:
```
var a =  struct {
  Clock clock.Clock
}{}

a.Clock = clock.Default
```
Now you may retrieve current time with:
```
a.Clock.Now()
```

In unit tests, mocking out your clock is simple with use of the `clocktest` pkg:
```
t0 := time.Now()
t1 := time.Now().Add(time.Second)

a.Clock = clocktest.New(t0, t1)

a.Clock.Now() // equal to t0
a.Clock.Now() // equal to t1
```
