### PR TITLE
Only start l2met provider when OTEL not enabled

### DIFF
--- a/cmdutil/metrics/metrics.go
+++ b/cmdutil/metrics/metrics.go
@@ -13,5 +13,8 @@ type Config struct {
 	Source         string        `env:"METRICS_SOURCE"`
 	Prefix         string        `env:"METRICS_PREFIX"`
 	DefaultTags    []string      `env:"METRICS_DEFAULT_TAGS"`
-	OTEL           otel.Config
+	// If OTEL is enabled, l2met is disabled, by default.
+	// Setting this value to `true` overrides that default.
+	L2MetEnabled bool `env:"METRICS_ENABLE_L2MET_COLLECTION"`
+	OTEL         otel.Config
 }

--- a/cmdutil/metrics/metrics.go
+++ b/cmdutil/metrics/metrics.go
@@ -15,6 +15,6 @@ type Config struct {
 	DefaultTags    []string      `env:"METRICS_DEFAULT_TAGS"`
 	// If OTEL is enabled, l2met is disabled, by default.
 	// Setting this value to `true` overrides that default.
-	L2MetEnabled bool `env:"METRICS_ENABLE_L2MET_COLLECTION"`
-	OTEL         otel.Config
+	L2MetOverrideEnabled bool `env:"METRICS_ENABLE_L2MET_OVERRIDE"`
+	OTEL                 otel.Config
 }

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -72,7 +72,7 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 		Logger: logger,
 	}
 
-	if !sc.Metrics.OTEL.Enabled {
+	if !sc.Metrics.OTEL.Enabled || sc.Metrics.L2MetEnabled {
 		l2met := l2met.New(logger)
 		s.MetricsProvider = l2met
 		s.Add(cmdutil.NewContextServer(l2met.Run))

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -72,9 +72,11 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 		Logger: logger,
 	}
 
-	l2met := l2met.New(logger)
-	s.MetricsProvider = l2met
-	s.Add(cmdutil.NewContextServer(l2met.Run))
+	if !sc.Metrics.OTEL.Enabled {
+		l2met := l2met.New(logger)
+		s.MetricsProvider = l2met
+		s.Add(cmdutil.NewContextServer(l2met.Run))
+	}
 
 	s.Add(debug.New(logger, sc.Debug.Port))
 	s.Add(signals.NewServer(logger, syscall.SIGINT, syscall.SIGTERM))

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -72,7 +72,7 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 		Logger: logger,
 	}
 
-	if !sc.Metrics.OTEL.Enabled || sc.Metrics.L2MetEnabled {
+	if !sc.Metrics.OTEL.Enabled || sc.Metrics.L2MetOverrideEnabled {
 		l2met := l2met.New(logger)
 		s.MetricsProvider = l2met
 		s.Add(cmdutil.NewContextServer(l2met.Run))


### PR DESCRIPTION
We don't want to run an `l2met` provider by default. With a [prior change](https://github.com/heroku/x/pull/179/files#diff-9692d64d304dc9da6aaa7ad1bac87402306ed56bb5507e9665598bc9e0f7b997L76-R77), that is now the behavior.

This PR changes the default behavior so that an `l2met` provider will only be started if OTEL is not enabled. This behavior can be overridden by setting the `METRICS_ENABLE_L2MET_OVERRIDE` env var, in which case, an `l2met` provider will be started regardless of the OTEL settings. 