### PR TITLE
Check if MetricsProvider is nil, avoid panics

### DIFF
--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -118,7 +118,9 @@ func (s *Standard) Run() {
 
 	// Not using defer here since it will have no effect if Fatal below
 	// is called.
-	s.MetricsProvider.Stop()
+	if s.MetricsProvider != nil {
+		s.MetricsProvider.Stop()
+	}
 
 	if err != nil {
 		s.Logger.WithError(err).Fatal()


### PR DESCRIPTION
When `service.Run()` exits, it's possible to panic because `MetricsProvider` may be `nil`.

In the future, we should perhaps set-up an OTEL provider or a NOOP provider by default.