### PR TITLE
cmdutil/service: improve panic reporting

### DIFF
--- a/cmdutil/metrics/metrics.go
+++ b/cmdutil/metrics/metrics.go
@@ -21,7 +21,7 @@ type Config struct {
 	OTEL                 otel.Config
 }
 
-// ReportPanic attempts to report the panic to rollbar via the logrus.
+// ReportPanic attempts to report the panic to rollbar via the metrics provider.
 func ReportPanic(metricsProvider xmetrics.Provider) {
 	if p := recover(); p != nil {
 		if metricsProvider != nil {

--- a/cmdutil/metrics/metrics.go
+++ b/cmdutil/metrics/metrics.go
@@ -18,3 +18,13 @@ type Config struct {
 	L2MetOverrideEnabled bool `env:"METRICS_ENABLE_L2MET_OVERRIDE"`
 	OTEL                 otel.Config
 }
+
+// ReportPanic attempts to report the panic to rollbar via the logrus.
+func ReportPanic(metricsProvider xmetrics.Provider) {
+	if p := recover(); p != nil {
+		if metricsProvider != nil {
+			metricsProvider.NewCounter("panic").Add(1)
+		}
+		panic(p)
+	}
+}

--- a/cmdutil/metrics/metrics.go
+++ b/cmdutil/metrics/metrics.go
@@ -26,6 +26,7 @@ func ReportPanic(metricsProvider xmetrics.Provider) {
 	if p := recover(); p != nil {
 		if metricsProvider != nil {
 			metricsProvider.NewCounter("panic").Add(1)
+			metricsProvider.Flush()
 		}
 		panic(p)
 	}

--- a/cmdutil/metrics/metrics.go
+++ b/cmdutil/metrics/metrics.go
@@ -21,7 +21,7 @@ type Config struct {
 	OTEL                 otel.Config
 }
 
-// ReportPanic attempts to report the panic to rollbar via the metrics provider.
+// ReportPanic attempts to report a panic via the metrics provider.
 func ReportPanic(metricsProvider xmetrics.Provider) {
 	if p := recover(); p != nil {
 		if metricsProvider != nil {

--- a/cmdutil/metrics/metrics.go
+++ b/cmdutil/metrics/metrics.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/heroku/x/cmdutil/metrics/otel"
+
+	xmetrics "github.com/heroku/x/go-kit/metrics"
 )
 
 // Config stores all the env related config to bootstrap metrics.

--- a/cmdutil/metrics/metrics_test.go
+++ b/cmdutil/metrics/metrics_test.go
@@ -13,7 +13,7 @@ func TestReportPanic(t *testing.T) {
 		if p := recover(); p == nil {
 			t.Fatal("expected ReportPanic to repanic")
 		}
-		mp.CheckObservationCount("panic", 1)
+		mp.CheckCounter("panic", 1)
 	}()
 
 	func() {

--- a/cmdutil/metrics/metrics_test.go
+++ b/cmdutil/metrics/metrics_test.go
@@ -18,7 +18,6 @@ func TestReportPanic(t *testing.T) {
 
 	func() {
 		defer ReportPanic(mp)
-
 		panic("test message")
 	}()
 }

--- a/cmdutil/metrics/metrics_test.go
+++ b/cmdutil/metrics/metrics_test.go
@@ -1,0 +1,24 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/heroku/x/go-kit/metrics/testmetrics"
+)
+
+func TestReportPanic(t *testing.T) {
+	mp := testmetrics.NewProvider(t)
+
+	defer func() {
+		if p := recover(); p == nil {
+			t.Fatal("expected ReportPanic to repanic")
+		}
+		mp.CheckObservationCount("panic", 1)
+	}()
+
+	func() {
+		defer ReportPanic(mp)
+
+		panic("test message")
+	}()
+}

--- a/cmdutil/rollbar/rollbar.go
+++ b/cmdutil/rollbar/rollbar.go
@@ -56,13 +56,6 @@ func shouldIgnore(err error) bool {
 	return false
 }
 
-// ReportPanic attempts to report the panic to rollbar via the logrus.
-func ReportPanic(logger logrus.FieldLogger) {
-	if p := recover(); p != nil {
-		logger.Panic(p)
-	}
-}
-
 var ignoreFuncs = []func(error) bool{
 	isCanceledOrEOF,
 	isTimeout,

--- a/cmdutil/rollbar/rollbar_test.go
+++ b/cmdutil/rollbar/rollbar_test.go
@@ -47,30 +47,6 @@ func TestShouldIgnore(t *testing.T) {
 	}
 }
 
-func TestReportPanic(t *testing.T) {
-	logger, hook := testlog.New()
-
-	defer func() {
-		if p := recover(); p == nil {
-			t.Fatal("expected ReportPanic to repanic")
-		}
-
-		entries := hook.Entries()
-		if want, got := 1, len(entries); want != got {
-			t.Fatalf("want hook entries to be %d, got %d", want, got)
-		}
-		if want, got := "test message", entries[0].Message; want != got {
-			t.Errorf("want hook entry message to be %q, got %q", want, got)
-		}
-	}()
-
-	func() {
-		defer ReportPanic(logger)
-
-		panic("test message")
-	}()
-}
-
 type tempError struct {
 	temporary bool
 }

--- a/cmdutil/rollbar/rollbar_test.go
+++ b/cmdutil/rollbar/rollbar_test.go
@@ -10,8 +10,6 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/heroku/x/testing/testlog"
 )
 
 func TestShouldIgnore(t *testing.T) {

--- a/cmdutil/service/integration_test.go
+++ b/cmdutil/service/integration_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+// +build integration
+
+package service
+
+import (
+	"os"
+	"testing"
+
+	"github.com/heroku/x/cmdutil"
+	"github.com/heroku/x/go-kit/metrics/l2met"
+)
+
+func TestPanicReporting(t *testing.T) {
+
+	os.Setenv("APP_NAME", "test-app")
+	os.Setenv("DEPLOY", "test")
+
+	t.Cleanup(func() {
+		os.Unsetenv("APP_NAME")
+		os.Unsetenv("DEPLOY")
+	})
+
+	var cfg struct {
+		Val string `env:"TEST_VAL,default=test"`
+	}
+
+	s := New(&cfg)
+
+	l2met := l2met.New(s.Logger)
+	s.MetricsProvider = l2met
+	s.Add(cmdutil.NewContextServer(l2met.Run))
+
+	f := func() error {
+		panic("test panic")
+		return nil
+	}
+
+	s.Add(cmdutil.ServerFunc(f))
+	s.Run()
+
+}

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -113,10 +113,8 @@ func (s *Standard) Add(svs ...cmdutil.Server) {
 // If the error returned by oklog/run.Run is non-nil, it is logged
 // with s.Logger.Fatal.
 func (s *Standard) Run() {
-	defer func() {
-		metrics.ReportPanic(s.MetricsProvider)
-		svclog.ReportPanic(s.Logger)
-	}()
+	defer metrics.ReportPanic(s.MetricsProvider)
+	defer svclog.ReportPanic(s.Logger)
 
 	err := s.g.Run()
 

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -102,6 +102,7 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 // Add adds cmdutil.Servers to be managed.
 func (s *Standard) Add(svs ...cmdutil.Server) {
 	for _, sv := range svs {
+		sv := sv
 		runWithPanicReport := func() error {
 			defer metrics.ReportPanic(s.MetricsProvider)
 			defer svclog.ReportPanic(s.Logger)

--- a/cmdutil/service/standard_test.go
+++ b/cmdutil/service/standard_test.go
@@ -48,31 +48,6 @@ func TestNewCustomConfig(t *testing.T) {
 	}
 }
 
-func TestReportPanic(t *testing.T) {
-	logger, hook := testlog.New()
-	mp := testmetrics.NewProvider(t)
-
-	defer func() {
-		if p := recover(); p == nil {
-			t.Fatal("expected ReportPanic to repanic")
-		}
-
-		entries := hook.Entries()
-		if want, got := 1, len(entries); want != got {
-			t.Fatalf("want hook entries to be %d, got %d", want, got)
-		}
-		if want, got := "test message", entries[0].Message; want != got {
-			t.Errorf("want hook entry message to be %q, got %q", want, got)
-		}
-	}()
-
-	func() {
-		defer ReportPanic(logger)
-
-		panic("test message")
-	}()
-}
-
 func setupStandardConfig(t *testing.T) {
 	os.Setenv("APP_NAME", "test-app")
 	os.Setenv("DEPLOY", "test")

--- a/cmdutil/service/standard_test.go
+++ b/cmdutil/service/standard_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/heroku/x/cmdutil/service"
-	"github.com/heroku/x/go-kit/metrics/testmetrics"
-	"github.com/heroku/x/testing/testlog"
 )
 
 func TestNewNoConfig(t *testing.T) {

--- a/cmdutil/service/standard_test.go
+++ b/cmdutil/service/standard_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/heroku/x/cmdutil/service"
+	"github.com/heroku/x/go-kit/metrics/testmetrics"
 	"github.com/heroku/x/testing/testlog"
 )
 
@@ -49,6 +50,7 @@ func TestNewCustomConfig(t *testing.T) {
 
 func TestReportPanic(t *testing.T) {
 	logger, hook := testlog.New()
+	mp := testmetrics.NewProvider(t)
 
 	defer func() {
 		if p := recover(); p == nil {

--- a/cmdutil/svclog/logger.go
+++ b/cmdutil/svclog/logger.go
@@ -40,7 +40,7 @@ func NewLogger(cfg Config) logrus.FieldLogger {
 }
 
 // ReportPanic attempts to report the panic to rollbar via the logrus.
-func ReportPanic(logger logrus.FieldLogger, metricsProvider xmetrics.Provider) {
+func ReportPanic(logger logrus.FieldLogger) {
 	if p := recover(); p != nil {
 		logger.Panic(p)
 	}

--- a/cmdutil/svclog/logger.go
+++ b/cmdutil/svclog/logger.go
@@ -39,6 +39,13 @@ func NewLogger(cfg Config) logrus.FieldLogger {
 	return logger
 }
 
+// ReportPanic attempts to report the panic to rollbar via the logrus.
+func ReportPanic(logger logrus.FieldLogger, metricsProvider xmetrics.Provider) {
+	if p := recover(); p != nil {
+		logger.Panic(p)
+	}
+}
+
 // NewSampleLogger creates a rate limited logger that samples logs. The parameter
 // logsBurstLimit defines how many logs are allowed per logBurstWindow duration.
 // The returned logger derives from the parentLogger, but without inheriting any Hooks.

--- a/cmdutil/svclog/logger_test.go
+++ b/cmdutil/svclog/logger_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/heroku/x/testing/testlog"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -87,6 +88,30 @@ func TestLoggerTrimsNewLineFromSaramaLoggerMsg(t *testing.T) {
 	if entry.Message != newMsg {
 		t.Fatalf("wanted message with new line char removed, got %q", entry.Message)
 	}
+}
+
+func TestReportPanic(t *testing.T) {
+	logger, hook := testlog.New()
+
+	defer func() {
+		if p := recover(); p == nil {
+			t.Fatal("expected ReportPanic to repanic")
+		}
+
+		entries := hook.Entries()
+		if want, got := 1, len(entries); want != got {
+			t.Fatalf("want hook entries to be %d, got %d", want, got)
+		}
+		if want, got := "test message", entries[0].Message; want != got {
+			t.Errorf("want hook entry message to be %q, got %q", want, got)
+		}
+	}()
+
+	func() {
+		defer ReportPanic(logger)
+
+		panic("test message")
+	}()
 }
 
 type dummyOutput struct {

--- a/cmdutil/svclog/logger_test.go
+++ b/cmdutil/svclog/logger_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/heroku/x/testing/testlog"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+
+	"github.com/heroku/x/testing/testlog"
 )
 
 func TestLoggerEmitsAppAndDeployData(t *testing.T) {

--- a/go-kit/metrics/l2met/l2met.go
+++ b/go-kit/metrics/l2met/l2met.go
@@ -138,4 +138,7 @@ func (p *Provider) log() {
 func (p *Provider) Stop() {}
 
 // Flush implements Provider.
-func (p *Provider) Flush() error { return nil }
+func (p *Provider) Flush() error {
+	p.log()
+	return nil
+}

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -127,6 +127,7 @@ func (f *Function) Start(handler interface{}) {
 
 	// Run logger, rollbar agent and metrics provider in the background.
 	go func() {
+		defer metrics.ReportPanic(f.MetricsProvider)
 		defer svclog.ReportPanic(f.Logger)
 
 		// Run any background servers, if configured.

--- a/lambda/function.go
+++ b/lambda/function.go
@@ -127,7 +127,7 @@ func (f *Function) Start(handler interface{}) {
 
 	// Run logger, rollbar agent and metrics provider in the background.
 	go func() {
-		defer rollbar.ReportPanic(f.Logger)
+		defer svclog.ReportPanic(f.Logger)
 
 		// Run any background servers, if configured.
 		// For example, the l2met agent.


### PR DESCRIPTION
## Rationale

We'd like to see a metric when we see panics in a standard service.

## Changes
* Add `ReportPanic` function to `cmdutil/metrics` that creates a counter `panic` on the metrics provider configured with a service.
* Move `ReportPanic` logging function to `cmdutil/svclog`
* L2met metrics provider now logs on `Flush`
* Add integration test that shows logs on a service panic for l2met and standard logger

## Meta 
* [W-13145387](https://gus.lightning.force.com/a07EE00001QhRMcYAN)