### PR TITLE
Make httpmetris work better with OTEL

### DIFF
--- a/hmiddleware/httpmetrics/httpmetrics.go
+++ b/hmiddleware/httpmetrics/httpmetrics.go
@@ -14,6 +14,11 @@ import (
 	"github.com/heroku/x/go-kit/metricsregistry"
 )
 
+const (
+	requestCount    = "http.server.requests"
+	requestDuration = "http.server.request-duration.ms"
+)
+
 // New returns an HTTP middleware which captures request metrics and reports
 // them to the given provider.
 func New(p metrics.Provider) func(http.Handler) http.Handler {
@@ -97,8 +102,8 @@ func NewV2(p metrics.Provider) func(http.Handler) http.Handler {
 				"response-status", sts,
 			}
 
-			reg.GetOrRegisterCounter("http.server.requests").With(labels...).Add(1)
-			reg.GetOrRegisterExplicitHistogram("http.server.request-duration.ms", metrics.ThirtySecondDistribution).With(labels...).Observe(ms(dur))
+			reg.GetOrRegisterCounter(requestCount).With(labels...).Add(1)
+			reg.GetOrRegisterExplicitHistogram(requestDuration, metrics.ThirtySecondDistribution).With(labels...).Observe(ms(dur))
 		})
 	}
 }

--- a/hmiddleware/httpmetrics/httpmetrics_v2.go
+++ b/hmiddleware/httpmetrics/httpmetrics_v2.go
@@ -67,7 +67,6 @@ func NewOTEL(p metrics.Provider) func(http.Handler) http.Handler {
 				labels = append(labels, kv...)
 			}
 
-			reg.GetOrRegisterCounter(activeRequests).With(labels...).Add(1)
 			reg.GetOrRegisterExplicitHistogram(requestDuration, metrics.ThirtySecondDistribution).With(labels...).Observe(ms(dur))
 		})
 	}

--- a/hmiddleware/httpmetrics/httpmetrics_v2.go
+++ b/hmiddleware/httpmetrics/httpmetrics_v2.go
@@ -25,11 +25,11 @@ const (
 	urlSchemeKey     = "url.scheme"
 )
 
-// NewV2 returns an HTTP middleware which captures HTTP request counts and latency
+// NewOTEL returns an HTTP middleware which captures HTTP request counts and latency
 // annotated with attributes for method, route, status.
 //
 // See https://opentelemetry.io/docs/specs/otel/metrics/semantic_conventions/http-metrics/
-func NewV2(p metrics.Provider) func(http.Handler) http.Handler {
+func NewOTEL(p metrics.Provider) func(http.Handler) http.Handler {
 	reg := metricsregistry.New(p)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/hmiddleware/httpmetrics/httpmetrics_v2.go
+++ b/hmiddleware/httpmetrics/httpmetrics_v2.go
@@ -5,14 +5,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
 	"github.com/heroku/x/go-kit/metrics"
 	"github.com/heroku/x/go-kit/metricsregistry"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
 )
 
 const (
-
 	// metric names
 	requestDuration = "http.server.duration"        // duration in milliseconds
 	activeRequests  = "http.server.active_requests" // counter for number of requests

--- a/hmiddleware/httpmetrics/httpmetrics_v2.go
+++ b/hmiddleware/httpmetrics/httpmetrics_v2.go
@@ -14,8 +14,7 @@ import (
 
 const (
 	// metric names
-	requestDuration = "http.server.duration"        // duration in milliseconds
-	activeRequests  = "http.server.active_requests" // counter for number of requests
+	requestDuration = "http.server.duration" // duration in milliseconds
 
 	// metric attribute keys
 	routeKey         = "http.route"

--- a/hmiddleware/httpmetrics/httpmetrics_v2.go
+++ b/hmiddleware/httpmetrics/httpmetrics_v2.go
@@ -1,0 +1,74 @@
+package httpmetrics
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"github.com/heroku/x/go-kit/metrics"
+	"github.com/heroku/x/go-kit/metricsregistry"
+)
+
+const (
+
+	// metric names
+	requestDuration = "http.server.duration"        // duration in milliseconds
+	activeRequests  = "http.server.active_requests" // counter for number of requests
+
+	// metric attribute keys
+	routeKey         = "http.route"
+	methodKey        = "http.request.method"
+	statusKey        = "http.response.status_code"
+	serverAddressKey = "server.address"
+	urlSchemeKey     = "url.scheme"
+)
+
+// NewV2 returns an HTTP middleware which captures HTTP request counts and latency
+// annotated with attributes for method, route, status.
+//
+// See https://opentelemetry.io/docs/specs/otel/metrics/semantic_conventions/http-metrics/
+func NewV2(p metrics.Provider) func(http.Handler) http.Handler {
+	reg := metricsregistry.New(p)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+			start := time.Now()
+			next.ServeHTTP(ww, r)
+			dur := time.Since(start)
+
+			labels := []string{
+				methodKey, r.Method,
+			}
+
+			if status := ww.Status(); status != 0 {
+				kv := []string{statusKey, strconv.Itoa(status)}
+				labels = append(labels, kv...)
+			}
+
+			ctx := r.Context()
+			if ctx.Value(chi.RouteCtxKey) != nil {
+				rtCtx := chi.RouteContext(ctx)
+				if len(rtCtx.RoutePatterns) > 0 {
+					// pick last route pattern as it is the one chi used
+					route := rtCtx.RoutePatterns[len(rtCtx.RoutePatterns)-1]
+					kv := []string{routeKey, route}
+					labels = append(labels, kv...)
+				}
+			}
+
+			if r.URL != nil {
+				kv := []string{
+					urlSchemeKey, r.URL.Scheme,
+					serverAddressKey, r.URL.Host,
+				}
+				labels = append(labels, kv...)
+			}
+
+			reg.GetOrRegisterCounter(activeRequests).With(labels...).Add(1)
+			reg.GetOrRegisterExplicitHistogram(requestDuration, metrics.ThirtySecondDistribution).With(labels...).Observe(ms(dur))
+		})
+	}
+}

--- a/hmiddleware/httpmetrics/httpmetrics_v2_test.go
+++ b/hmiddleware/httpmetrics/httpmetrics_v2_test.go
@@ -25,8 +25,6 @@ func TestOTELMiddleware(t *testing.T) {
 	hand := NewOTEL(p)(next)
 	hand.ServeHTTP(w, r)
 
-	p.CheckCounter("http.server.active_requests.http.request.method:GET:url.scheme:http:server.address:example.org", 1)
-
 	p.CheckObservationCount("http.server.duration.http.request.method:GET:url.scheme:http:server.address:example.org", 1)
 }
 
@@ -42,8 +40,6 @@ func TestOTELResponseStatus(t *testing.T) {
 
 	hand := NewOTEL(p)(next)
 	hand.ServeHTTP(w, r)
-
-	p.CheckCounter("http.server.active_requests.http.request.method:GET:http.response.status_code:502:url.scheme:http:server.address:example.org", 1)
 
 	p.CheckObservationCount("http.server.duration.http.request.method:GET:http.response.status_code:502:url.scheme:http:server.address:example.org", 1)
 }
@@ -65,7 +61,6 @@ func TestOTELChi(t *testing.T) {
 	hand := NewOTEL(p)(next)
 	hand.ServeHTTP(w, r)
 
-	p.CheckCounter("http.server.active_requests.http.request.method:GET:http.route:/apps/{foo_id}/bars/{bar_id}:url.scheme:http:server.address:example.org", 1)
 	p.CheckObservationCount("http.server.duration.http.request.method:GET:http.route:/apps/{foo_id}/bars/{bar_id}:url.scheme:http:server.address:example.org", 1)
 
 }
@@ -89,7 +84,6 @@ func TestOTELNestedChiRouters(t *testing.T) {
 	w := httptest.NewRecorder()
 	outer.ServeHTTP(w, r)
 
-	p.CheckCounter("http.server.active_requests.http.request.method:GET:http.response.status_code:200:http.route:/hello/{name}:url.scheme:http:server.address:example.org", 1)
 	p.CheckObservationCount("http.server.duration.http.request.method:GET:http.response.status_code:200:http.route:/hello/{name}:url.scheme:http:server.address:example.org", 1)
 
 }

--- a/hmiddleware/httpmetrics/httpmetrics_v2_test.go
+++ b/hmiddleware/httpmetrics/httpmetrics_v2_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/heroku/x/go-kit/metrics/testmetrics"
 )
 
-func TestV2Middleware(t *testing.T) {
+func TestOTELMiddleware(t *testing.T) {
 	p := testmetrics.NewProvider(t)
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -22,7 +22,7 @@ func TestV2Middleware(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://example.org/foo/bar", nil)
 	w := httptest.NewRecorder()
 
-	hand := NewV2(p)(next)
+	hand := NewOTEL(p)(next)
 	hand.ServeHTTP(w, r)
 
 	p.CheckCounter("http.server.active_requests.http.request.method:GET:url.scheme:http:server.address:example.org", 1)
@@ -30,7 +30,7 @@ func TestV2Middleware(t *testing.T) {
 	p.CheckObservationCount("http.server.duration.http.request.method:GET:url.scheme:http:server.address:example.org", 1)
 }
 
-func TestV2ResponseStatus(t *testing.T) {
+func TestOTELResponseStatus(t *testing.T) {
 	p := testmetrics.NewProvider(t)
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +40,7 @@ func TestV2ResponseStatus(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://example.org/foo/bar", nil)
 	w := httptest.NewRecorder()
 
-	hand := NewV2(p)(next)
+	hand := NewOTEL(p)(next)
 	hand.ServeHTTP(w, r)
 
 	p.CheckCounter("http.server.active_requests.http.request.method:GET:http.response.status_code:502:url.scheme:http:server.address:example.org", 1)
@@ -48,7 +48,7 @@ func TestV2ResponseStatus(t *testing.T) {
 	p.CheckObservationCount("http.server.duration.http.request.method:GET:http.response.status_code:502:url.scheme:http:server.address:example.org", 1)
 }
 
-func TestV2Chi(t *testing.T) {
+func TestOTELChi(t *testing.T) {
 	p := testmetrics.NewProvider(t)
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -62,7 +62,7 @@ func TestV2Chi(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	hand := NewV2(p)(next)
+	hand := NewOTEL(p)(next)
 	hand.ServeHTTP(w, r)
 
 	p.CheckCounter("http.server.active_requests.http.request.method:GET:http.route:/apps/{foo_id}/bars/{bar_id}:url.scheme:http:server.address:example.org", 1)
@@ -70,7 +70,7 @@ func TestV2Chi(t *testing.T) {
 
 }
 
-func TestV2NestedChiRouters(t *testing.T) {
+func TestOTELNestedChiRouters(t *testing.T) {
 	p := testmetrics.NewProvider(t)
 
 	inner := chi.NewRouter()
@@ -82,7 +82,7 @@ func TestV2NestedChiRouters(t *testing.T) {
 	})
 
 	outer := chi.NewRouter()
-	outer.Use(NewV2(p))
+	outer.Use(NewOTEL(p))
 	outer.Mount("/", inner)
 
 	r := httptest.NewRequest("GET", "http://example.org/hello/world", nil)

--- a/hmiddleware/httpmetrics/httpmetrics_v2_test.go
+++ b/hmiddleware/httpmetrics/httpmetrics_v2_test.go
@@ -1,0 +1,95 @@
+package httpmetrics
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi"
+
+	"github.com/heroku/x/go-kit/metrics/testmetrics"
+)
+
+func TestV2Middleware(t *testing.T) {
+	p := testmetrics.NewProvider(t)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	})
+
+	r := httptest.NewRequest("GET", "http://example.org/foo/bar", nil)
+	w := httptest.NewRecorder()
+
+	hand := NewV2(p)(next)
+	hand.ServeHTTP(w, r)
+
+	p.CheckCounter("http.server.active_requests.http.request.method:GET:url.scheme:http:server.address:example.org", 1)
+
+	p.CheckObservationCount("http.server.duration.http.request.method:GET:url.scheme:http:server.address:example.org", 1)
+}
+
+func TestV2ResponseStatus(t *testing.T) {
+	p := testmetrics.NewProvider(t)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(502)
+	})
+
+	r := httptest.NewRequest("GET", "http://example.org/foo/bar", nil)
+	w := httptest.NewRecorder()
+
+	hand := NewV2(p)(next)
+	hand.ServeHTTP(w, r)
+
+	p.CheckCounter("http.server.active_requests.http.request.method:GET:http.response.status_code:502:url.scheme:http:server.address:example.org", 1)
+
+	p.CheckObservationCount("http.server.duration.http.request.method:GET:http.response.status_code:502:url.scheme:http:server.address:example.org", 1)
+}
+
+func TestV2Chi(t *testing.T) {
+	p := testmetrics.NewProvider(t)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	})
+
+	r := httptest.NewRequest("GET", "http://example.org/foo/bar", nil)
+
+	rctx := chi.NewRouteContext()
+	rctx.RoutePatterns = []string{"/*", "/apps/{foo_id}/bars/{bar_id}"}
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+
+	hand := NewV2(p)(next)
+	hand.ServeHTTP(w, r)
+
+	p.CheckCounter("http.server.active_requests.http.request.method:GET:http.route:/apps/{foo_id}/bars/{bar_id}:url.scheme:http:server.address:example.org", 1)
+	p.CheckObservationCount("http.server.duration.http.request.method:GET:http.route:/apps/{foo_id}/bars/{bar_id}:url.scheme:http:server.address:example.org", 1)
+
+}
+
+func TestV2NestedChiRouters(t *testing.T) {
+	p := testmetrics.NewProvider(t)
+
+	inner := chi.NewRouter()
+	inner.Get("/hello/{name}", func(w http.ResponseWriter, r *http.Request) {
+		name := chi.URLParam(r, "id")
+		if _, err := io.WriteString(w, fmt.Sprintf("Hello %s!", name)); err != nil {
+			t.Fatal("unexpected error", err)
+		}
+	})
+
+	outer := chi.NewRouter()
+	outer.Use(NewV2(p))
+	outer.Mount("/", inner)
+
+	r := httptest.NewRequest("GET", "http://example.org/hello/world", nil)
+	w := httptest.NewRecorder()
+	outer.ServeHTTP(w, r)
+
+	p.CheckCounter("http.server.active_requests.http.request.method:GET:http.response.status_code:200:http.route:/hello/{name}:url.scheme:http:server.address:example.org", 1)
+	p.CheckObservationCount("http.server.duration.http.request.method:GET:http.response.status_code:200:http.route:/hello/{name}:url.scheme:http:server.address:example.org", 1)
+
+}


### PR DESCRIPTION
## Rationale

Here we add a option to improve HTTP metrics reporting with OTEL.

## Changes
* Add `NewV2` function to `httpmetrics` which uses attributes over metric names

## Meta
[W-13781478](https://gus.lightning.force.com/a07EE00001WSFXiYAP)
