### PR TITLE
Prefer built-in multiplexer

### DIFF
--- a/dynoid/dynoidtest/dynoidtest.go
+++ b/dynoid/dynoidtest/dynoidtest.go
@@ -7,11 +7,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/go-chi/chi"
 	"github.com/golang-jwt/jwt/v4"
 	jose "gopkg.in/square/go-jose.v2"
 )
@@ -70,9 +70,14 @@ type roundTripper struct {
 }
 
 func (rt *roundTripper) init() {
-	r := chi.NewRouter()
+	mux := http.NewServeMux()
 
-	r.Get("/issuers/test/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/issuers/test/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.EqualFold(r.Method, http.MethodGet) {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
 		header := w.Header()
 		header.Set("Content-Type", "application/json")
 
@@ -89,7 +94,12 @@ func (rt *roundTripper) init() {
 			`}`))
 	})
 
-	r.Get("/issuers/test/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/issuers/test/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.EqualFold(r.Method, http.MethodGet) {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
 		jwks := &jose.JSONWebKeySet{}
 		jwks.Keys = append(jwks.Keys, jose.JSONWebKey{Key: rt.issuer.key.Public(), KeyID: "primary"})
 
@@ -102,7 +112,7 @@ func (rt *roundTripper) init() {
 		_ = enc.Encode(jwks)
 	})
 
-	rt.handler = r
+	rt.handler = mux
 }
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
This uses `http.ServeMux` for the `dynoidtest` package. There is no need for it to take a dependency on something else.