### PR TITLE
Update newHistogram of testmetrics Provider

### DIFF
--- a/go-kit/metrics/testmetrics/provider.go
+++ b/go-kit/metrics/testmetrics/provider.go
@@ -181,8 +181,14 @@ func (p *Provider) CheckObservations(name string, obs []float64, labelValues ...
 	p.t.Helper()
 
 	observations := p.getObservations(name, labelValues...)
-	if !reflect.DeepEqual(observations, obs) {
-		p.t.Fatalf("%v = %v, want %v", p.keyFor(name, labelValues...), observations, obs)
+	got := make([]float64, len(observations))
+	copy(got, observations)
+
+	want := make([]float64, len(obs))
+	copy(want, obs)
+
+	if !reflect.DeepEqual(got, want) {
+		p.t.Fatalf("%v = %v, want %v", p.keyFor(name, labelValues...), got, want)
 	}
 }
 

--- a/go-kit/metrics/testmetrics/provider.go
+++ b/go-kit/metrics/testmetrics/provider.go
@@ -94,7 +94,7 @@ func (p *Provider) newHistogram(name string, labelValues ...string) metrics.Hist
 
 	k := p.keyFor(name, labelValues...)
 	if _, ok := p.histograms[k]; !ok {
-		p.histograms[k] = &Histogram{name: name, p: p, labelValues: labelValues}
+		p.histograms[k] = &Histogram{name: name, p: p, labelValues: labelValues, observations: []float64{}}
 	}
 	return p.histograms[k]
 }

--- a/go-kit/metrics/testmetrics/provider.go
+++ b/go-kit/metrics/testmetrics/provider.go
@@ -181,14 +181,8 @@ func (p *Provider) CheckObservations(name string, obs []float64, labelValues ...
 	p.t.Helper()
 
 	observations := p.getObservations(name, labelValues...)
-	got := make([]float64, len(observations))
-	copy(got, observations)
-
-	want := make([]float64, len(obs))
-	copy(want, obs)
-
-	if !reflect.DeepEqual(got, want) {
-		p.t.Fatalf("%v = %v, want %v", p.keyFor(name, labelValues...), got, want)
+	if !reflect.DeepEqual(observations, obs) {
+		p.t.Fatalf("%v = %v, want %v", p.keyFor(name, labelValues...), observations, obs)
 	}
 }
 


### PR DESCRIPTION
**Reason For the Change:** 

While using testmetrics provider in the testcases, we observed CheckObservation is failing when we don't add anything inside the Histogram. 

When we are sending an empty float64 list:  `empty := float64[]` to CheckObservation, it was failing .  

The reason is, we are not initializing observations in the newHistogram function of the testmetrics provider. 

**Changes:** 

Initializing the observations of Histogram in newHistogram function.  
