### PR TITLE
Properly construct auth header for OTEL Metric endpoints

### DIFF
--- a/go-kit/metrics/provider/otel/options.go
+++ b/go-kit/metrics/provider/otel/options.go
@@ -127,7 +127,7 @@ func WithHTTPEndpointExporter(endpoint string, options ...otlpmetrichttp.Option)
 
 		if u.User.String() != "" {
 			authHeader := make(map[string]string)
-			authHeader["Authorization"] = "Basic" + base64.StdEncoding.EncodeToString([]byte(u.User.String()))
+			authHeader["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(u.User.String()))
 
 			defaults = append(defaults, otlpmetrichttp.WithHeaders(authHeader))
 		}
@@ -160,7 +160,7 @@ func WithGRPCExporter(endpoint string, options ...otlpmetricgrpc.Option) Option 
 
 		if u.User.String() != "" {
 			authHeader := make(map[string]string)
-			authHeader["Authorization"] = "Basic" + base64.StdEncoding.EncodeToString([]byte(u.User.String()))
+			authHeader["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(u.User.String()))
 
 			defaults = append(defaults, otlpmetricgrpc.WithHeaders(authHeader))
 		}


### PR DESCRIPTION
Discovered that services using latest version of OTEL utilities from `x` would get authorization failures sending metrics to OTEL collectors that required auth.  Tracked down this bug.