### PR TITLE
Use RWMutex in OTEL provider

### DIFF
--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -40,7 +40,7 @@ type Provider struct {
 	meterProvider *metric.MeterProvider
 	viewCache     *viewCache
 
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	counters   map[string]*Counter
 	gauges     map[string]*Gauge
 	histograms map[string]*Histogram


### PR DESCRIPTION
Currently, the `otel.Provider` uses a `sync.Mutex` to protect against race conditions on the maps that store instances of the different metric types. The mutex blocks to ensure the existence of a metric on metric modification. 

We can avoid fully blocking on reads for already existing metrics with a `sync.RWMutex`. 