### PR TITLE
Set up a pprof server with optional mutex profiling in cmdutil

### DIFF
--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/google/gops/agent"
@@ -131,10 +130,9 @@ func NewPProfServer(config ProfileConfig, l logrus.FieldLogger) *PProfServer {
 // It implements oklog group's runFn.
 func (s *PProfServer) Run() error {
 	s.logger.WithFields(logrus.Fields{
-		"at":       "binding",
-		"service":  "pprof",
-		"addr":     s.addr,
-		"profiles": strings.Join(s.getProfileNames(), ","),
+		"at":      "binding",
+		"service": "pprof",
+		"addr":    s.addr,
 	}).Info()
 
 	if s.pprofServer != nil {
@@ -161,13 +159,4 @@ func (s *PProfServer) Stop(_ error) {
 		}
 	}
 	close(s.done)
-}
-
-// getProfileNames returns the list of profile names configured.
-func (s *PProfServer) getProfileNames() []string {
-	var profiles []string
-	for profile := range s.profileConfig.ProfileHandlers {
-		profiles = append(profiles, profile)
-	}
-	return profiles
 }

--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -41,10 +41,9 @@ func New(l logrus.FieldLogger, port int) *Server {
 
 // Server wraps a gops server for easy use with oklog/group.
 type Server struct {
-	logger      logrus.FieldLogger
-	addr        string
-	done        chan struct{}
-	pprofServer *http.Server
+	logger logrus.FieldLogger
+	addr   string
+	done   chan struct{}
 }
 
 // Run starts the debug server.
@@ -65,14 +64,6 @@ func (s *Server) Run() error {
 		return err
 	}
 
-	if s.pprofServer != nil {
-		go func() {
-			if err := s.pprofServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				s.logger.WithError(err).Error("pprof server error")
-			}
-		}()
-	}
-
 	<-s.done
 	return nil
 }
@@ -84,14 +75,6 @@ func (s *Server) Stop(_ error) {
 	agent.Close()
 
 	close(s.done)
-
-	if s.pprofServer != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := s.pprofServer.Shutdown(ctx); err != nil {
-			s.logger.WithError(err).Error("Error shutting down pprof server")
-		}
-	}
 }
 
 // PProfServer wraps a pprof server.

--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -125,16 +125,18 @@ func NewPProfServer(config PProfServerConfig, l logrus.FieldLogger) *PProfServer
 //
 // It implements oklog group's runFn.
 func (s *PProfServer) Run() error {
+	if s.pprofServer == nil {
+		return fmt.Errorf("pprofServer is nil")
+	}
+
 	s.logger.WithFields(logrus.Fields{
 		"at":      "binding",
 		"service": "pprof",
 		"addr":    s.addr,
 	}).Info()
 
-	if s.pprofServer != nil {
-		if err := s.pprofServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			return err
-		}
+	if err := s.pprofServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
 	}
 
 	<-s.done

--- a/cmdutil/debug/debug_test.go
+++ b/cmdutil/debug/debug_test.go
@@ -63,49 +63,36 @@ func TestNewPProfServer(t *testing.T) {
 			}
 			runtime.SetMutexProfileFraction(tt.expectedMutexFraction) // Reset to the expected value
 
-			// Perform HTTP GET requests to ensure the server is running and all handlers respond correctly
-			profiles := []string{"", "heap", "goroutine", "threadcreate", "block", "mutex"}
-			for _, profile := range profiles {
-				url := "http://" + server.addr + "/debug/pprof/" + profile
-				resp, err := http.Get(url)
-				if err != nil {
-					t.Errorf("http.Get(%s) error = %v", url, err)
-				}
-				if resp.StatusCode != http.StatusOK {
-					t.Errorf("http.Get(%s) status = %v, want %v", url, resp.StatusCode, http.StatusOK)
-				}
+			urls := []string{
+				"http://" + server.addr + "/debug/pprof/",
+				"http://" + server.addr + "/debug/pprof/heap",
+				"http://" + server.addr + "/debug/pprof/goroutine",
+				"http://" + server.addr + "/debug/pprof/threadcreate",
+				"http://" + server.addr + "/debug/pprof/block",
+				"http://" + server.addr + "/debug/pprof/mutex",
 			}
 
-			// urls := []string{
-			// 	"http://" + server.addr + "/debug/pprof/",
-			// 	"http://" + server.addr + "/debug/pprof/heap",
-			// 	"http://" + server.addr + "/debug/pprof/goroutine",
-			// 	"http://" + server.addr + "/debug/pprof/threadcreate",
-			// 	"http://" + server.addr + "/debug/pprof/block",
-			// 	"http://" + server.addr + "/debug/pprof/mutex",
-			// }
+			// Perform HTTP GET requests to ensure the server is running and all handlers respond correctly
+			client := &http.Client{}
+			for _, url := range urls {
+				t.Run("GET "+url, func(t *testing.T) {
+					req, err := http.NewRequest("GET", url, nil)
+					if err != nil {
+						t.Errorf("http.NewRequest(%s) error = %v", url, err)
+					}
 
-			// // Perform HTTP GET requests to ensure the server is running and all handlers respond correctly
-			// client := &http.Client{}
-			// for _, url := range urls {
-			// 	t.Run("GET "+url, func(t *testing.T) {
-			// 		req, err := http.NewRequest("GET", url, nil)
-			// 		if err != nil {
-			// 			t.Errorf("http.NewRequest(%s) error = %v", url, err)
-			// 		}
+					resp, err := client.Do(req)
+					if err != nil {
+						t.Errorf("http.Client.Do() error = %v", err)
+					}
 
-			// 		resp, err := client.Do(req)
-			// 		if err != nil {
-			// 			t.Errorf("http.Client.Do() error = %v", err)
-			// 		}
+					if resp.StatusCode != http.StatusOK {
+						t.Errorf("http.Client.Do() status = %v, want %v", resp.StatusCode, http.StatusOK)
+					}
 
-			// 		if resp.StatusCode != http.StatusOK {
-			// 			t.Errorf("http.Client.Do() status = %v, want %v", resp.StatusCode, http.StatusOK)
-			// 		}
-
-			// 		resp.Body.Close()
-			// 	})
-			// }
+					resp.Body.Close()
+				})
+			}
 
 			// Stop the server
 			server.Stop(nil)

--- a/cmdutil/debug/debug_test.go
+++ b/cmdutil/debug/debug_test.go
@@ -63,36 +63,27 @@ func TestNewPProfServer(t *testing.T) {
 			}
 			runtime.SetMutexProfileFraction(tt.expectedMutexFraction) // Reset to the expected value
 
-			urls := []string{
-				"http://" + server.addr + "/debug/pprof/",
-				"http://" + server.addr + "/debug/pprof/heap",
-				"http://" + server.addr + "/debug/pprof/goroutine",
-				"http://" + server.addr + "/debug/pprof/threadcreate",
-				"http://" + server.addr + "/debug/pprof/block",
-				"http://" + server.addr + "/debug/pprof/mutex",
-			}
-
-			// Perform HTTP GET requests to ensure the server is running and all handlers respond correctly
+			// Perform HTTP GET request to the root path
+			url := "http://" + server.addr + "/debug/pprof/"
 			client := &http.Client{}
-			for _, url := range urls {
-				t.Run("GET "+url, func(t *testing.T) {
-					req, err := http.NewRequest("GET", url, nil)
-					if err != nil {
-						t.Errorf("http.NewRequest(%s) error = %v", url, err)
-					}
 
-					resp, err := client.Do(req)
-					if err != nil {
-						t.Errorf("http.Client.Do() error = %v", err)
-					}
+			t.Run("GET "+url, func(t *testing.T) {
+				req, err := http.NewRequest("GET", url, nil)
+				if err != nil {
+					t.Errorf("http.NewRequest(%s) error = %v", url, err)
+				}
 
-					if resp.StatusCode != http.StatusOK {
-						t.Errorf("http.Client.Do() status = %v, want %v", resp.StatusCode, http.StatusOK)
-					}
+				resp, err := client.Do(req)
+				if err != nil {
+					t.Errorf("http.Client.Do() error = %v", err)
+				}
 
-					resp.Body.Close()
-				})
-			}
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("http.Client.Do() status = %v, want %v", resp.StatusCode, http.StatusOK)
+				}
+
+				resp.Body.Close()
+			})
 
 			// Stop the server
 			server.Stop(nil)

--- a/cmdutil/debug/debug_test.go
+++ b/cmdutil/debug/debug_test.go
@@ -1,0 +1,122 @@
+package debug
+
+import (
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestNewPProfServer(t *testing.T) {
+	logger := logrus.New()
+
+	tests := []struct {
+		name                  string
+		config                PProfServerConfig
+		expectedAddr          string
+		expectedMutexFraction int
+	}{
+		{
+			name:                  "DefaultAddr",
+			config:                PProfServerConfig{},
+			expectedAddr:          "127.0.0.1:9998",
+			expectedMutexFraction: defaultMutexProfileFraction,
+		},
+		{
+			name:                  "CustomAddr",
+			config:                PProfServerConfig{Addr: "127.0.0.1:9090"},
+			expectedAddr:          "127.0.0.1:9090",
+			expectedMutexFraction: defaultMutexProfileFraction,
+		},
+		{
+			name:                  "CustomMutexProfileFraction",
+			config:                PProfServerConfig{MutexProfileFraction: 5},
+			expectedAddr:          "127.0.0.1:9998",
+			expectedMutexFraction: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := NewPProfServer(tt.config, logger)
+
+			// Check server address
+			if server.addr != tt.expectedAddr {
+				t.Errorf("NewPProfServer() addr = %v, want %v", server.addr, tt.expectedAddr)
+			}
+
+			// Start the server
+			go func() {
+				if err := server.Run(); err != nil {
+					t.Errorf("NewPProfServer() run error = %v", err)
+				}
+			}()
+
+			// Give the server a moment to start
+			time.Sleep(100 * time.Millisecond)
+
+			// Check mutex profile fraction
+			if got := runtime.SetMutexProfileFraction(0); got != tt.expectedMutexFraction {
+				t.Errorf("runtime.SetMutexProfileFraction() = %v, want %v", got, tt.expectedMutexFraction)
+			}
+			runtime.SetMutexProfileFraction(tt.expectedMutexFraction) // Reset to the expected value
+
+			// Perform HTTP GET requests to ensure the server is running and all handlers respond correctly
+			profiles := []string{"", "heap", "goroutine", "threadcreate", "block", "mutex"}
+			for _, profile := range profiles {
+				url := "http://" + server.addr + "/debug/pprof/" + profile
+				resp, err := http.Get(url)
+				if err != nil {
+					t.Errorf("http.Get(%s) error = %v", url, err)
+				}
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("http.Get(%s) status = %v, want %v", url, resp.StatusCode, http.StatusOK)
+				}
+			}
+
+			// urls := []string{
+			// 	"http://" + server.addr + "/debug/pprof/",
+			// 	"http://" + server.addr + "/debug/pprof/heap",
+			// 	"http://" + server.addr + "/debug/pprof/goroutine",
+			// 	"http://" + server.addr + "/debug/pprof/threadcreate",
+			// 	"http://" + server.addr + "/debug/pprof/block",
+			// 	"http://" + server.addr + "/debug/pprof/mutex",
+			// }
+
+			// // Perform HTTP GET requests to ensure the server is running and all handlers respond correctly
+			// client := &http.Client{}
+			// for _, url := range urls {
+			// 	t.Run("GET "+url, func(t *testing.T) {
+			// 		req, err := http.NewRequest("GET", url, nil)
+			// 		if err != nil {
+			// 			t.Errorf("http.NewRequest(%s) error = %v", url, err)
+			// 		}
+
+			// 		resp, err := client.Do(req)
+			// 		if err != nil {
+			// 			t.Errorf("http.Client.Do() error = %v", err)
+			// 		}
+
+			// 		if resp.StatusCode != http.StatusOK {
+			// 			t.Errorf("http.Client.Do() status = %v, want %v", resp.StatusCode, http.StatusOK)
+			// 		}
+
+			// 		resp.Body.Close()
+			// 	})
+			// }
+
+			// Stop the server
+			server.Stop(nil)
+
+			// Ensure the server is stopped
+			select {
+			case <-server.done:
+				// success
+			case <-time.After(1 * time.Second):
+				t.Fatal("server did not stop in time")
+			}
+		})
+	}
+}

--- a/cmdutil/server.go
+++ b/cmdutil/server.go
@@ -4,6 +4,9 @@ package cmdutil
 
 import (
 	"context"
+	"net/http"
+	"net/http/pprof"
+	"runtime"
 
 	"github.com/oklog/run"
 )
@@ -92,4 +95,80 @@ func MultiServer(servers ...Server) Server {
 		RunFunc:  g.Run,
 		StopFunc: s.Stop,
 	}
+}
+
+// NewPprofServer sets up a pprof server with optional mutex profiling.
+// func NewPprofServer(addr string, enableMutexProfiling bool) Server {
+//     if addr == "" {
+//         addr = "127.0.0.1:9998" // Default port
+//     }
+
+//     return NewContextServer(func(ctx context.Context) error {
+//         if enableMutexProfiling {
+//             runtime.SetMutexProfileFraction(2)
+//         }
+
+//         pprofSrv := &http.Server{
+//             Addr:    addr,
+//             Handler: http.HandlerFunc(pprof.Index),
+//         }
+
+//         go func() {
+//             <-ctx.Done()
+//             pprofSrv.Close()
+//         }()
+
+//         return pprofSrv.ListenAndServe()
+//     })
+// }
+
+// ProfileConfig holds the configuration for the pprof server.
+type ProfileConfig struct {
+	Addr     string
+	Profiles []string
+}
+
+// NewPprofServer sets up a pprof server with optional mutex profiling and configurable profiling types.
+func NewPprofServer(config ProfileConfig) Server {
+	if config.Addr == "" {
+		config.Addr = "127.0.0.1:9998" // Default port
+	}
+
+	return NewContextServer(func(ctx context.Context) error {
+		mux := http.NewServeMux()
+
+		profileHandlers := map[string]http.HandlerFunc{
+			"index":        pprof.Index,
+			"cmdline":      pprof.Cmdline,
+			"profile":      pprof.Profile,
+			"symbol":       pprof.Symbol,
+			"heap":         pprof.Handler("heap").ServeHTTP,
+			"goroutine":    pprof.Handler("goroutine").ServeHTTP,
+			"threadcreate": pprof.Handler("threadcreate").ServeHTTP,
+			"block":        pprof.Handler("block").ServeHTTP,
+			"trace":        pprof.Trace,
+			"mutex":        pprof.Handler("mutex").ServeHTTP,
+		}
+
+		for _, profile := range config.Profiles {
+			if handler, exists := profileHandlers[profile]; exists {
+				if profile == "mutex" {
+					runtime.SetMutexProfileFraction(2)
+				}
+				mux.HandleFunc("/debug/pprof/"+profile, handler)
+			}
+		}
+
+		pprofSrv := &http.Server{
+			Addr:    config.Addr,
+			Handler: mux,
+		}
+
+		go func() {
+			<-ctx.Done()
+			pprofSrv.Close()
+		}()
+
+		return pprofSrv.ListenAndServe()
+	})
 }

--- a/cmdutil/server.go
+++ b/cmdutil/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"runtime"
+	"time"
 
 	"github.com/oklog/run"
 )
@@ -160,8 +161,9 @@ func NewPprofServer(config ProfileConfig) Server {
 		}
 
 		pprofSrv := &http.Server{
-			Addr:    config.Addr,
-			Handler: mux,
+			Addr:              config.Addr,
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
 		}
 
 		go func() {


### PR DESCRIPTION
**Description**

We want to configure the pprof listener that is capable of running mutex profiles on server set-up in `cmdutil/debug`. This PR created a new `NewPprofServer` method to the `cmdutil/debug` package, allowing for the setup of a `pprof` server with configurable profiling types and optional mutex profiling. 


**Changes**
- Add `PProfServerConfig` struct: holds configuration for the pprof server.
- Add `PProfServer` struct: wraps a pprof server
- Implement `NewPProfServer` function: creates and configures the pprof server.
- Implement `Run` and `Stop` methods: the `NewPProfServer` function includes `Run` and `Stop` methods for managing the pprof server lifecycle.
- Write unit tests for `NewPProfServer`

**Metadata**
[W-16252388](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001wqPSIYA2/view)


