### PR TITLE
Refactor and Start PProf debug server

### DIFF
--- a/cmdutil/debug/config.go
+++ b/cmdutil/debug/config.go
@@ -7,12 +7,7 @@ type Config struct {
 }
 
 type PProfConfig struct {
-	PProfPort            int  `env:"DEBUG_PPROF_PORT,default=9998"`
-	EnablePProfDebugging bool `env:"DEBUG_PPROF_ENABLE,default=false"`
-
-	// Mutex Profiling is not enabled by default
-	EnableMutexProfiling bool `env:"DEBUG_PPROF_MUTEX_PROFILE_ENABLE,default=false"`
-
+	PProfPort int `env:"DEBUG_PPROF_PORT,default=9998"`
 	// This controls how much of fraction of mutexes we need to consider for profiling.
 	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
 
@@ -22,10 +17,15 @@ type PProfConfig struct {
 	// Default is actual default value of MemProfileRate
 	MemProfileRate int `env:"DBEUG_PPROF_MEM_PROFILE_RATE,default=524288"`
 
-	// Block Profiling is not enabled default
-	EnableBlockProfiling bool `env:"DEBUG_PPROF_BLOCK_PROFILE_ENABLE,default=false"`
-
 	// This controls how much blocking time in nano seconds we need to consider.
 	// Default 10 indicates, we consider all 10 ns blocking events .
 	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
+
+	EnablePProfDebugging bool `env:"DEBUG_PPROF_ENABLE,default=false"`
+
+	// Mutex Profiling is not enabled by default
+	EnableMutexProfiling bool `env:"DEBUG_PPROF_MUTEX_PROFILE_ENABLE,default=false"`
+
+	// Block Profiling is not enabled default
+	EnableBlockProfiling bool `env:"DEBUG_PPROF_BLOCK_PROFILE_ENABLE,default=false"`
 }

--- a/cmdutil/debug/config.go
+++ b/cmdutil/debug/config.go
@@ -3,13 +3,11 @@ package debug
 // Config describes the configurable parameters for debugging.
 type Config struct {
 	Port int `env:"DEBUG_PORT,default=9999"`
-	PProfConfig
+	PProf
 }
 
-type PProfConfig struct {
-	PProfPort int `env:"DEBUG_PPROF_PORT,default=9998"`
-	// This controls how much of fraction of mutexes we need to consider for profiling.
-	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
+type PProf struct {
+	Port int `env:"DEBUG_PPROF_PORT,default=9998"`
 
 	// Heap Profiling is enabled by default.
 	// This controls the frequency of heap allocation sampling.
@@ -17,15 +15,18 @@ type PProfConfig struct {
 	// Default is actual default value of MemProfileRate
 	MemProfileRate int `env:"DBEUG_PPROF_MEM_PROFILE_RATE,default=524288"`
 
-	// This controls how much blocking time in nano seconds we need to consider.
-	// Default 10 indicates, we consider all 10 ns blocking events .
-	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
-
-	EnablePProfDebugging bool `env:"DEBUG_PPROF_ENABLE,default=false"`
+	Enabled bool `env:"DEBUG_PPROF_ENABLE,default=false"`
 
 	// Mutex Profiling is not enabled by default
 	EnableMutexProfiling bool `env:"DEBUG_PPROF_MUTEX_PROFILE_ENABLE,default=false"`
 
+	// This controls how much of fraction of mutexes we need to consider for profiling.
+	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
+
 	// Block Profiling is not enabled default
 	EnableBlockProfiling bool `env:"DEBUG_PPROF_BLOCK_PROFILE_ENABLE,default=false"`
+
+	// This controls how much blocking time in nano seconds we need to consider.
+	// Default 10 indicates, we consider all 10 ns blocking events .
+	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
 }

--- a/cmdutil/debug/config.go
+++ b/cmdutil/debug/config.go
@@ -8,25 +8,19 @@ type Config struct {
 
 type PProf struct {
 	Port int `env:"DEBUG_PPROF_PORT,default=9998"`
-
-	// This controls how much of fraction of mutexes we need to consider for profiling.
-	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
-
-	// This controls how much blocking time in nano seconds we need to consider.
-	// Default 10 indicates, we consider all 10 ns blocking events .
-	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
-
 	// Heap Profiling is enabled by default.
 	// This controls the frequency of heap allocation sampling.
 	// It defines the number of bytes allocated between samples.
 	// Default is actual default value of MemProfileRate
-	MemProfileRate int `env:"DBEUG_PPROF_MEM_PROFILE_RATE,default=524288"`
-
-	Enabled bool `env:"DEBUG_PPROF_ENABLE,default=false"`
-
+	MemProfileRate int  `env:"DBEUG_PPROF_MEM_PROFILE_RATE,default=524288"`
+	Enabled        bool `env:"DEBUG_PPROF_ENABLE,default=false"`
 	// Mutex Profiling is not enabled by default
 	EnableMutexProfiling bool `env:"DEBUG_PPROF_MUTEX_PROFILE_ENABLE,default=false"`
-
+	// This controls how much of fraction of mutexes we need to consider for profiling.
+	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
 	// Block Profiling is not enabled default
 	EnableBlockProfiling bool `env:"DEBUG_PPROF_BLOCK_PROFILE_ENABLE,default=false"`
+	// This controls how much blocking time in nano seconds we need to consider.
+	// Default 10 indicates, we consider all 10 ns blocking events .
+	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
 }

--- a/cmdutil/debug/config.go
+++ b/cmdutil/debug/config.go
@@ -2,8 +2,30 @@ package debug
 
 // Config describes the configurable parameters for debugging.
 type Config struct {
-	Port                 int  `env:"DEBUG_PORT,default=9999"`
-	PprofPort            int  `env:"PPROF_DEBUG_PORT,default=9998"`
-	EnablePprofDebugging bool `env:"ENABLE_PPROF_DEBUGGING,default=false"`
-	MutexProfileFraction int  `env:"MUTEX_PROFILE_FRACTION,default=2"`
+	Port int `env:"DEBUG_PORT,default=9999"`
+	PProfConfig
+}
+
+type PProfConfig struct {
+	PProfPort            int  `env:"PPROF_DEBUG_PORT,default=9998"`
+	EnablePProfDebugging bool `env:"DEBUG_PPROF_ENABLE,default=false"`
+
+	// Mutex Profiling is not enabled by default
+	EnableMutexProfiling bool `env:"DEBUG_PPROF_MUTEX_PROFILE_ENABLE,default=false"`
+
+	// This controls how much of fraction of mutexes we need to consider for profiling.
+	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
+
+	// Heap Profiling is enabled by default.
+	// This controls the frequency of heap allocation sampling.
+	// It defines the number of bytes allocated between samples.
+	// Default is actual default value of MemProfileRate
+	MemProfileRate int `env:"DBEUG_MEM_PROFILE_RATE,default=524288"`
+
+	// Block Profiling is not enabled default
+	EnableBlockProfiling bool `env:"DEBUG_PPROF_BLOCK_PROFILE_ENABLE,default=false"`
+
+	// This controls how much blocking time in nano seconds we need to consider.
+	// Default 10 indicates, we consider all 10 ns blocking events .
+	BlockProfileRate int `env:"DBEUG_BLOCK_PROFILE_RATE,default=10"`
 }

--- a/cmdutil/debug/config.go
+++ b/cmdutil/debug/config.go
@@ -8,6 +8,11 @@ type Config struct {
 
 type PProf struct {
 	Port int `env:"DEBUG_PPROF_PORT,default=9998"`
+	// This controls how much of fraction of mutexes we need to consider for profiling.
+	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
+	// This controls how much blocking time in nano seconds we need to consider.
+	// Default 10 indicates, we consider all 10 ns blocking events .
+	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
 	// Heap Profiling is enabled by default.
 	// This controls the frequency of heap allocation sampling.
 	// It defines the number of bytes allocated between samples.
@@ -16,11 +21,6 @@ type PProf struct {
 	Enabled        bool `env:"DEBUG_PPROF_ENABLE,default=false"`
 	// Mutex Profiling is not enabled by default
 	EnableMutexProfiling bool `env:"DEBUG_PPROF_MUTEX_PROFILE_ENABLE,default=false"`
-	// This controls how much of fraction of mutexes we need to consider for profiling.
-	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
 	// Block Profiling is not enabled default
 	EnableBlockProfiling bool `env:"DEBUG_PPROF_BLOCK_PROFILE_ENABLE,default=false"`
-	// This controls how much blocking time in nano seconds we need to consider.
-	// Default 10 indicates, we consider all 10 ns blocking events .
-	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
 }

--- a/cmdutil/debug/config.go
+++ b/cmdutil/debug/config.go
@@ -9,6 +9,13 @@ type Config struct {
 type PProf struct {
 	Port int `env:"DEBUG_PPROF_PORT,default=9998"`
 
+	// This controls how much of fraction of mutexes we need to consider for profiling.
+	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
+
+	// This controls how much blocking time in nano seconds we need to consider.
+	// Default 10 indicates, we consider all 10 ns blocking events .
+	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
+
 	// Heap Profiling is enabled by default.
 	// This controls the frequency of heap allocation sampling.
 	// It defines the number of bytes allocated between samples.
@@ -20,13 +27,6 @@ type PProf struct {
 	// Mutex Profiling is not enabled by default
 	EnableMutexProfiling bool `env:"DEBUG_PPROF_MUTEX_PROFILE_ENABLE,default=false"`
 
-	// This controls how much of fraction of mutexes we need to consider for profiling.
-	MutexProfileFraction int `env:"DBEUG_PPROF_MUTEX_PROFILE_FRACTION,default=2"`
-
 	// Block Profiling is not enabled default
 	EnableBlockProfiling bool `env:"DEBUG_PPROF_BLOCK_PROFILE_ENABLE,default=false"`
-
-	// This controls how much blocking time in nano seconds we need to consider.
-	// Default 10 indicates, we consider all 10 ns blocking events .
-	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
 }

--- a/cmdutil/debug/config.go
+++ b/cmdutil/debug/config.go
@@ -7,7 +7,7 @@ type Config struct {
 }
 
 type PProfConfig struct {
-	PProfPort            int  `env:"PPROF_DEBUG_PORT,default=9998"`
+	PProfPort            int  `env:"DEBUG_PPROF_PORT,default=9998"`
 	EnablePProfDebugging bool `env:"DEBUG_PPROF_ENABLE,default=false"`
 
 	// Mutex Profiling is not enabled by default
@@ -20,12 +20,12 @@ type PProfConfig struct {
 	// This controls the frequency of heap allocation sampling.
 	// It defines the number of bytes allocated between samples.
 	// Default is actual default value of MemProfileRate
-	MemProfileRate int `env:"DBEUG_MEM_PROFILE_RATE,default=524288"`
+	MemProfileRate int `env:"DBEUG_PPROF_MEM_PROFILE_RATE,default=524288"`
 
 	// Block Profiling is not enabled default
 	EnableBlockProfiling bool `env:"DEBUG_PPROF_BLOCK_PROFILE_ENABLE,default=false"`
 
 	// This controls how much blocking time in nano seconds we need to consider.
 	// Default 10 indicates, we consider all 10 ns blocking events .
-	BlockProfileRate int `env:"DBEUG_BLOCK_PROFILE_RATE,default=10"`
+	BlockProfileRate int `env:"DBEUG_PPROF_BLOCK_PROFILE_RATE,default=10"`
 }

--- a/cmdutil/debug/config.go
+++ b/cmdutil/debug/config.go
@@ -2,5 +2,8 @@ package debug
 
 // Config describes the configurable parameters for debugging.
 type Config struct {
-	Port int `env:"DEBUG_PORT,default=9999"`
+	Port                 int  `env:"DEBUG_PORT,default=9999"`
+	PprofPort            int  `env:"PPROF_DEBUG_PORT,default=9998"`
+	EnablePprofDebugging bool `env:"ENABLE_PPROF_DEBUGGING,default=false"`
+	MutexProfileFraction int  `env:"MUTEX_PROFILE_FRACTION,default=2"`
 }

--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -78,7 +78,11 @@ func (s *Server) Run() error {
 
 	wg.Wait()
 	gopsErr := <-gopsErrChan
-	pprofErr := <-pprofErrChan
+	var pprofErr error
+	if s.pprof != nil {
+		pprofErr = <-pprofErrChan
+	}
+
 	var err error
 	if gopsErr != nil {
 		err = fmt.Errorf("gops error: %w", gopsErr)

--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -33,6 +33,8 @@ import (
 // Connect to the debug server with gops:
 //
 //	gops stack localhost:PORT
+//
+// Connect to the pprof server with pprof.port when pprof enabled
 func New(l logrus.FieldLogger, config Config) *Server {
 	server := &Server{
 		logger: l,
@@ -166,8 +168,6 @@ func NewPProfServer(l logrus.FieldLogger, pprofConfig *PProf) *PProfServer {
 }
 
 // Run starts the pprof server.
-//
-// It implements oklog group's runFn.
 func (s *PProfServer) Run() error {
 	if s.pprofServer == nil {
 		return fmt.Errorf("pprofServer is nil")
@@ -188,8 +188,6 @@ func (s *PProfServer) Run() error {
 }
 
 // Stop shuts down the pprof server.
-//
-// It implements oklog group's interruptFn.
 func (s *PProfServer) Stop(_ error) {
 	if s.pprofServer != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -86,7 +86,7 @@ type PProfServer struct {
 }
 
 // NewPProfServer sets up a pprof server with configurable profiling types and returns a PProfServer instance.
-func NewPProfServer(l logrus.FieldLogger, pprofConfig *PProfConfig) *PProfServer {
+func NewPProfServer(l logrus.FieldLogger, pprofConfig *PProf) *PProfServer {
 
 	runtime.MemProfileRate = pprofConfig.MemProfileRate
 
@@ -99,7 +99,7 @@ func NewPProfServer(l logrus.FieldLogger, pprofConfig *PProfConfig) *PProfServer
 	}
 
 	httpServer := &http.Server{
-		Addr:              fmt.Sprintf("127.0.0.1:%d", pprofConfig.PProfPort),
+		Addr:              fmt.Sprintf("127.0.0.1:%d", pprofConfig.Port),
 		Handler:           http.HandlerFunc(pprof.Index),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
@@ -126,7 +126,6 @@ func (s *PProfServer) Run() error {
 		"addr":    s.addr,
 	}).Info()
 
-	// runtime.MemProfileRecord
 	if err := s.pprofServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return err
 	}

--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -85,37 +85,19 @@ type PProfServer struct {
 	pprofServer *http.Server
 }
 
-// ProfileConfig holds the configuration for the pprof server.
-type PProfServerConfig struct {
-	Addr                 string
-	MutexProfileFraction int
-}
-
-// defaultMutexProfileFraction is the default value for MutexProfileFraction
-const defaultMutexProfileFraction = 2
-
 // NewPProfServer sets up a pprof server with configurable profiling types and returns a PProfServer instance.
-func NewPProfServer(config PProfServerConfig, l logrus.FieldLogger) *PProfServer {
-	if config.Addr == "" {
-		config.Addr = "127.0.0.1:9998" // Default port
-	}
-
-	// Use a local variable for the mutex profile fraction
-	mpf := defaultMutexProfileFraction
-	if config.MutexProfileFraction != 0 {
-		mpf = config.MutexProfileFraction
-	}
-	runtime.SetMutexProfileFraction(mpf)
+func NewPProfServer(l logrus.FieldLogger, port int, mutexProfileFraction int) *PProfServer {
+	runtime.SetMutexProfileFraction(mutexProfileFraction)
 
 	httpServer := &http.Server{
-		Addr:              config.Addr,
+		Addr:              fmt.Sprintf("127.0.0.1:%d", port),
 		Handler:           http.HandlerFunc(pprof.Index),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	return &PProfServer{
 		logger:      l,
-		addr:        config.Addr,
+		addr:        httpServer.Addr,
 		done:        make(chan struct{}),
 		pprofServer: httpServer,
 	}

--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -79,7 +79,7 @@ func (s *Server) Run() error {
 			defer wg.Done()
 			pprofErr = s.pprof.Run()
 			if pprofErr != nil {
-				s.pprof.logger.WithError(gopsErr).Error("pprof server failed")
+				s.pprof.logger.WithError(pprofErr).Error("pprof server failed")
 			}
 		}()
 	}

--- a/cmdutil/debug/debug_test.go
+++ b/cmdutil/debug/debug_test.go
@@ -11,36 +11,34 @@ import (
 
 func TestNewPProfServer(t *testing.T) {
 	logger := logrus.New()
+	defaultMutexProfileFraction := 2
 
 	tests := []struct {
 		name                  string
-		config                PProfServerConfig
 		expectedAddr          string
 		expectedMutexFraction int
+		port                  int
+		mutexProfileFraction  int
 	}{
 		{
-			name:                  "DefaultAddr",
-			config:                PProfServerConfig{},
+			name:                  "test port as 9998 and mpf as 2",
 			expectedAddr:          "127.0.0.1:9998",
+			port:                  9998,
+			mutexProfileFraction:  defaultMutexProfileFraction,
 			expectedMutexFraction: defaultMutexProfileFraction,
 		},
 		{
-			name:                  "CustomAddr",
-			config:                PProfServerConfig{Addr: "127.0.0.1:9090"},
-			expectedAddr:          "127.0.0.1:9090",
-			expectedMutexFraction: defaultMutexProfileFraction,
-		},
-		{
-			name:                  "CustomMutexProfileFraction",
-			config:                PProfServerConfig{MutexProfileFraction: 5},
-			expectedAddr:          "127.0.0.1:9998",
-			expectedMutexFraction: 5,
+			name:                  "test port as 9997 and mpf as 4",
+			expectedAddr:          "127.0.0.1:9997",
+			port:                  9997,
+			mutexProfileFraction:  4,
+			expectedMutexFraction: 4,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := NewPProfServer(tt.config, logger)
+			server := NewPProfServer(logger, tt.port, tt.mutexProfileFraction)
 
 			// Check server address
 			if server.addr != tt.expectedAddr {

--- a/cmdutil/debug/debug_test.go
+++ b/cmdutil/debug/debug_test.go
@@ -15,26 +15,26 @@ func TestNewPProfServer(t *testing.T) {
 	tests := []struct {
 		name                   string
 		expectedAddr           string
-		pprofConfig            *PProfConfig
+		pprofConfig            *PProf
 		expectedMemProfileRate int
 	}{
 		{
 			name:         "test port as 9998 and mpf as 2",
 			expectedAddr: "127.0.0.1:9998",
-			pprofConfig: &PProfConfig{
-				PProfPort:            9998,
-				EnablePProfDebugging: true,
-				MemProfileRate:       524288,
+			pprofConfig: &PProf{
+				Port:           9998,
+				Enabled:        true,
+				MemProfileRate: 524288,
 			},
 			expectedMemProfileRate: 524288,
 		},
 		{
 			name:         "test port as 9997 and mpf as 4",
 			expectedAddr: "127.0.0.1:9997",
-			pprofConfig: &PProfConfig{
-				PProfPort:            9997,
-				EnablePProfDebugging: true,
-				MemProfileRate:       524287,
+			pprofConfig: &PProf{
+				Port:           9997,
+				Enabled:        true,
+				MemProfileRate: 524287,
 			},
 			expectedMemProfileRate: 524287,
 		},

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -73,10 +73,7 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 		s.Add(cmdutil.NewContextServer(l2met.Run))
 	}
 
-	s.Add(debug.New(logger, sc.Debug.Port))
-	if sc.Debug.Enabled {
-		s.Add(debug.NewPProfServer(logger, &sc.Debug.PProf))
-	}
+	s.Add(debug.New(logger, sc.Debug))
 	s.Add(signals.NewServer(logger, syscall.SIGINT, syscall.SIGTERM))
 
 	// only setup an exporter if indicated && the AgentAddress is set

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -74,6 +74,9 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 	}
 
 	s.Add(debug.New(logger, sc.Debug.Port))
+	if sc.Debug.EnablePprofDebugging {
+		s.Add(debug.NewPProfServer(logger, sc.Debug.PprofPort, sc.Debug.MutexProfileFraction))
+	}
 	s.Add(signals.NewServer(logger, syscall.SIGINT, syscall.SIGTERM))
 
 	// only setup an exporter if indicated && the AgentAddress is set

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -74,8 +74,8 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 	}
 
 	s.Add(debug.New(logger, sc.Debug.Port))
-	if sc.Debug.EnablePprofDebugging {
-		s.Add(debug.NewPProfServer(logger, sc.Debug.PprofPort, sc.Debug.MutexProfileFraction))
+	if sc.Debug.EnablePProfDebugging {
+		s.Add(debug.NewPProfServer(logger, &sc.Debug.PProfConfig))
 	}
 	s.Add(signals.NewServer(logger, syscall.SIGINT, syscall.SIGTERM))
 

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -74,8 +74,8 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 	}
 
 	s.Add(debug.New(logger, sc.Debug.Port))
-	if sc.Debug.EnablePProfDebugging {
-		s.Add(debug.NewPProfServer(logger, &sc.Debug.PProfConfig))
+	if sc.Debug.Enabled {
+		s.Add(debug.NewPProfServer(logger, &sc.Debug.PProf))
 	}
 	s.Add(signals.NewServer(logger, syscall.SIGINT, syscall.SIGTERM))
 


### PR DESCRIPTION
**Description**

We want to start the PProf debug server from Standard based on a config


**Changes**
- Updated debug config
- updated NewPProf Server
- Updated standard to start PProf based on EnablePprofDebugging config

**Metadata**
[W-16499473](https://gus.lightning.force.com/a07EE00001z1VZ9YAM)