### PR TITLE
go-kit: Add CheckCounterExists for testmetrics

### DIFF
--- a/go-kit/metrics/testmetrics/provider.go
+++ b/go-kit/metrics/testmetrics/provider.go
@@ -171,7 +171,7 @@ func (p *Provider) CheckNoCounter(name string, labelValues ...string) {
 }
 
 // CheckCounterExists checks that there is registered counter with the name
-// provided and value is greater than 0.
+// provided and value is not 0.
 func (p *Provider) CheckCounterExists(name string, labelValues ...string) {
 	p.t.Helper()
 

--- a/go-kit/metrics/testmetrics/provider.go
+++ b/go-kit/metrics/testmetrics/provider.go
@@ -170,6 +170,24 @@ func (p *Provider) CheckNoCounter(name string, labelValues ...string) {
 	}
 }
 
+// CheckCounterExists checks that there is registered counter with the name
+// provided and value is greater than 0.
+func (p *Provider) CheckCounterExists(name string, labelValues ...string) {
+	p.t.Helper()
+
+	p.Lock()
+	defer p.Unlock()
+
+	k := p.keyFor(name, labelValues...)
+	counter, ok := p.counters[k]
+	if !ok {
+		p.t.Fatalf("a counter named %s was not found", k)
+	}
+	if counter.value == 0 {
+		p.t.Fatalf("counter %s value is 0", k)
+	}
+}
+
 // CheckObservationsMinMax checks that there is a histogram
 // with the name and that the values all fall within the min/max range.
 func (p *Provider) CheckObservationsMinMax(name string, min, max float64, labelValues ...string) {


### PR DESCRIPTION
Adding a `CheckCounterExists` function to `testmetrics` would be helpful for scenarios where we need to verify that a metric exists and is not 0, but we can't determine the exact counter value.
