### PR TITLE
Add Option to wait while stopping Server

### DIFF
--- a/cmdutil/service/config.go
+++ b/cmdutil/service/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/heroku/x/cmdutil/metrics"
 	"github.com/heroku/x/cmdutil/oc"
 	"github.com/heroku/x/cmdutil/rollbar"
+	"github.com/heroku/x/cmdutil/signals"
 	"github.com/heroku/x/cmdutil/svclog"
 )
 
@@ -17,6 +18,7 @@ type standardConfig struct {
 	Logger     svclog.Config
 	Metrics    metrics.Config
 	Rollbar    rollbar.Config
+	Signals    signals.Config
 	OpenCensus oc.Config
 }
 

--- a/cmdutil/service/standard.go
+++ b/cmdutil/service/standard.go
@@ -74,7 +74,7 @@ func New(appConfig interface{}, ofs ...OptionFunc) *Standard {
 	}
 
 	s.Add(debug.New(logger, sc.Debug))
-	s.Add(signals.NewServer(logger, syscall.SIGINT, syscall.SIGTERM))
+	s.Add(signals.NewServer(logger, sc.Signals, syscall.SIGINT, syscall.SIGTERM))
 
 	// only setup an exporter if indicated && the AgentAddress is set
 	// this separates the code change saying yes, do tracing from

--- a/cmdutil/signals/config.go
+++ b/cmdutil/signals/config.go
@@ -1,6 +1,8 @@
 package signals
 
+import "time"
+
 // Config describes the configurable parameters for Signals server.
 type Config struct {
-	ServerCloseWaitTime int `env:"SERVER_CLOSE_WAIT_TIME,default=0"`
+	SignalsServerStopDelay time.Duration `env:"SIGNALS_SERVER_STOP_DELAY,default=0s"`
 }

--- a/cmdutil/signals/config.go
+++ b/cmdutil/signals/config.go
@@ -1,0 +1,6 @@
+package signals
+
+// Config describes the configurable parameters for Signals server.
+type Config struct {
+	ServerCloseWaitTime int `env:"SERVER_CLOSE_WAIT_TIME,default=0"`
+}

--- a/cmdutil/signals/signals.go
+++ b/cmdutil/signals/signals.go
@@ -44,7 +44,7 @@ func NewServer(logger logrus.FieldLogger, config Config, signals ...os.Signal) c
 			if sig != nil {
 				logger.Infoln("received signal", sig)
 			}
-			time.Sleep(time.Duration(config.ServerCloseWaitTime) * time.Second)
+			time.Sleep(config.SignalsServerStopDelay)
 			return nil
 		},
 		StopFunc: func(error) {

--- a/cmdutil/signals/signals.go
+++ b/cmdutil/signals/signals.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -33,7 +34,7 @@ func notifyContext(ctx context.Context, notified chan os.Signal, signals ...os.S
 // NewServer returns a cmdutil.Server that returns from Run
 // when any of the provided signals are received.
 // Run always returns a nil error.
-func NewServer(logger logrus.FieldLogger, signals ...os.Signal) cmdutil.Server {
+func NewServer(logger logrus.FieldLogger, config Config, signals ...os.Signal) cmdutil.Server {
 	ch := make(chan os.Signal, 1)
 
 	return cmdutil.ServerFuncs{
@@ -43,6 +44,7 @@ func NewServer(logger logrus.FieldLogger, signals ...os.Signal) cmdutil.Server {
 			if sig != nil {
 				logger.Infoln("received signal", sig)
 			}
+			time.Sleep(time.Duration(config.ServerCloseWaitTime) * time.Second)
 			return nil
 		},
 		StopFunc: func(error) {

--- a/cmdutil/signals/signals_test.go
+++ b/cmdutil/signals/signals_test.go
@@ -25,7 +25,7 @@ func TestWithNotifyCancel(t *testing.T) {
 func TestNewServer(t *testing.T) {
 	logger, _ := testlog.New()
 
-	tcConfig := Config{ServerCloseWaitTime: 0}
+	tcConfig := Config{}
 	sv := NewServer(logger, tcConfig, syscall.SIGWINCH)
 
 	var (
@@ -72,7 +72,7 @@ func TestNewServer(t *testing.T) {
 func TestNewServerWithWait(t *testing.T) {
 	logger, _ := testlog.New()
 
-	tcConfig := Config{ServerCloseWaitTime: 2}
+	tcConfig := Config{SignalsServerStopDelay: 2 * time.Second}
 	sv := NewServer(logger, tcConfig, syscall.SIGWINCH)
 
 	var (
@@ -127,7 +127,7 @@ func TestNewServerWithWait(t *testing.T) {
 func TestNewServerNoSignal(t *testing.T) {
 	logger, _ := testlog.New()
 
-	tcConfig := Config{ServerCloseWaitTime: 0}
+	tcConfig := Config{SignalsServerStopDelay: 0}
 	sv := NewServer(logger, tcConfig, syscall.SIGWINCH)
 
 	var runErr error


### PR DESCRIPTION
## Reasons for making these changes

Currently there is option to wait before shutting down server when we receive an interrupt Signal. We want to add wait time to signals server,  so that other severs running using the standard server will have time to do any shutdown shenanigans.

## Description of changes

- added SIGNALS_SERVER_STOP_DELAY with default 0
- added signals config
- added wait insider signals server
- update standardConfig.

[W-16790435](https://gus.lightning.force.com/a07EE000021ZVpgYAG)