### PR TITLE
Update CodeQL to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: CI
 
 on: [ push ]
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,9 @@
 name: "Code Scanning"
 
 on:
+  push:
+    branches:
+      - master
   schedule:
     - cron: '0 12 * * 6'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
   schedule:
     - cron: '0 12 * * 6'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: "Code scanning - action"
+name: "Code Scanning"
 
 on:
   schedule:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       # Override language selection by uncommenting this and choosing your languages
       with:
         languages: go
@@ -33,7 +33,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -47,4 +47,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       # Override language selection by uncommenting this and choosing your languages
       with:
         languages: go
@@ -33,7 +33,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -47,4 +47,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,11 +20,6 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # x
 
-![CI Testing Status](https://github.com/heroku/x/workflows/ci/badge.svg)&nbsp;[![GoDoc](https://godoc.org/github.com/heroku/x?status.svg)](http://godoc.org/github.com/heroku/x)&nbsp;![Security Code Scanning - action](https://github.com/heroku/x/workflows/Code%20scanning%20-%20action/badge.svg)
+![CI Testing Status](https://github.com/heroku/x/workflows/CI/badge.svg)&nbsp;[![GoDoc](https://godoc.org/github.com/heroku/x?status.svg)](http://godoc.org/github.com/heroku/x)&nbsp;![Security Code Scanning](https://github.com/heroku/x/workflows/Code%20Scanning/badge.svg)
 
 A set of packages for reuse within Heroku Go applications.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heroku/x
 
-go 1.21
+go 1.21.0
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0


### PR DESCRIPTION
## Rationale
Update to the latest version of the codeql action to get updated scanners.

## Changes
- Update action to `v3`.
- Update `go.mod` to conform to the go `x.y.z` version.
- Always run codeql when a PR is merged.

## Links
- [v2 Release](https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/)
- [v3 Release](https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/)