### PR TITLE
Update go-chi to 5.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.34.0
 	github.com/axiomhq/hyperloglog v0.0.0-20180317131949-fe9507de0228
 	github.com/coreos/go-oidc/v3 v3.11.0
-	github.com/go-chi/chi v4.1.2+incompatible
+	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-kit/kit v0.9.0
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/golang/protobuf v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
-github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
 github.com/go-jose/go-jose/v4 v4.0.2/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
 github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=

--- a/hmiddleware/example_test.go
+++ b/hmiddleware/example_test.go
@@ -11,8 +11,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	tags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/sirupsen/logrus"
 )

--- a/hmiddleware/httpmetrics/example_test.go
+++ b/hmiddleware/httpmetrics/example_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 
 	"github.com/heroku/x/go-kit/metrics/testmetrics"
 	"github.com/heroku/x/hmiddleware/httpmetrics"

--- a/hmiddleware/httpmetrics/httpmetrics.go
+++ b/hmiddleware/httpmetrics/httpmetrics.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/heroku/x/go-kit/metrics"
 	"github.com/heroku/x/go-kit/metricsregistry"

--- a/hmiddleware/httpmetrics/httpmetrics_otel.go
+++ b/hmiddleware/httpmetrics/httpmetrics_otel.go
@@ -9,8 +9,8 @@ import (
 	"github.com/heroku/x/go-kit/metrics"
 	"github.com/heroku/x/go-kit/metricsregistry"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 )
 
 const (

--- a/hmiddleware/httpmetrics/httpmetrics_otel_test.go
+++ b/hmiddleware/httpmetrics/httpmetrics_otel_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 
 	"github.com/heroku/x/go-kit/metrics/testmetrics"
 )

--- a/hmiddleware/httpmetrics/httpmetrics_test.go
+++ b/hmiddleware/httpmetrics/httpmetrics_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 
 	"github.com/heroku/x/go-kit/metrics/testmetrics"
 )

--- a/hmiddleware/logger.go
+++ b/hmiddleware/logger.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/heroku/x/requestid"
 

--- a/hmiddleware/logger_test.go
+++ b/hmiddleware/logger_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/heroku/x/testing/testlog"
 )

--- a/hmiddleware/request_logger.go
+++ b/hmiddleware/request_logger.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/pkg/errors"
 
 	"github.com/heroku/x/requestid"

--- a/hmiddleware/request_logger_test.go
+++ b/hmiddleware/request_logger_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 	tags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 
 	"github.com/heroku/x/testing/testlog"
 
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/sirupsen/logrus"
 )
 

--- a/hmiddleware/requestid_test.go
+++ b/hmiddleware/requestid_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v5"
 
 	"github.com/heroku/x/hcontext"
 )


### PR DESCRIPTION
Older versions of `go-chi` have a security vulnerability ([noted here](https://pkg.go.dev/vuln/GO-2025-3770)). This PR updates the `go-chi` version to 5.2.2

[Slack Convo ](https://salesforce-internal.slack.com/archives/C2LA11J4S/p1753815891905679)