### PR TITLE
Add flexible base resource option to otel provider

### DIFF
--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+
 	xmetrics "github.com/heroku/x/go-kit/metrics"
 )
 
@@ -78,10 +80,14 @@ type exporterFactory func(*config) (metric.Exporter, error)
 // New returns a new, unstarted Provider. Use its Start() method to start
 // and establish a connection with its exporter's collector agent.
 func New(ctx context.Context, serviceName string, opts ...Option) (xmetrics.Provider, error) {
+	// Start with environment detection but strip the schema to avoid conflicts
+	base := resource.Default()
+	schemalessBase := resource.NewSchemaless(base.Attributes()...)
+
 	cfg := &config{
 		ctx:             ctx,
 		collectPeriod:   DefaultReaderInterval,
-		serviceResource: nil,
+		serviceResource: schemalessBase,
 	}
 	defaultOpts := []Option{
 		WithServiceStandard(serviceName),
@@ -96,9 +102,12 @@ func New(ctx context.Context, serviceName string, opts ...Option) (xmetrics.Prov
 		}
 	}
 
-	// If no resource was provided, use the default
-	if cfg.serviceResource == nil {
-		cfg.serviceResource = resource.Default()
+	// If no schema was provided by user, add library's default schema
+	if cfg.serviceResource.SchemaURL() == "" {
+		cfg.serviceResource = resource.NewWithAttributes(
+			semconv.SchemaURL,
+			cfg.serviceResource.Attributes()...,
+		)
 	}
 
 	p := Provider{

--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -81,7 +81,7 @@ func New(ctx context.Context, serviceName string, opts ...Option) (xmetrics.Prov
 	cfg := &config{
 		ctx:             ctx,
 		collectPeriod:   DefaultReaderInterval,
-		serviceResource: resource.Default(), // this fetches from env by default and pre-populates some fields.
+		serviceResource: nil,
 	}
 	defaultOpts := []Option{
 		WithServiceStandard(serviceName),
@@ -94,6 +94,11 @@ func New(ctx context.Context, serviceName string, opts ...Option) (xmetrics.Prov
 		if err := opt(cfg); err != nil {
 			return nil, fmt.Errorf("failed to apply options: %w", err)
 		}
+	}
+
+	// If no resource was provided, use the default
+	if cfg.serviceResource == nil {
+		cfg.serviceResource = resource.Default()
 	}
 
 	p := Provider{

--- a/go-kit/metrics/provider/otel/resource.go
+++ b/go-kit/metrics/provider/otel/resource.go
@@ -127,12 +127,6 @@ func WithEnvironmentStandard(env string) Option {
 // duplicate attributes will be overwritten.
 func WithResource(res *resource.Resource) Option {
 	return func(cfg *config) error {
-		// If no base resource exists yet, use the provided resource directly
-		if cfg.serviceResource == nil {
-			cfg.serviceResource = res
-			return nil
-		}
-
 		merged, err := resource.Merge(cfg.serviceResource, res)
 		if err != nil {
 			return fmt.Errorf("failed to merge resources: %w", err)

--- a/go-kit/metrics/provider/otel/resource.go
+++ b/go-kit/metrics/provider/otel/resource.go
@@ -104,8 +104,7 @@ func EnvironmentConv(stage string) []attribute.KeyValue {
 // WithOpenTelemetryStandardService returns an Option that configures service
 // attributes according to open-telemetry semconv conventions.
 func WithOpenTelemetryStandardService(name, namespace, instanceID string) Option {
-	return WithResource(resource.NewWithAttributes(
-		semconv.SchemaURL,
+	return WithResource(resource.NewSchemaless(
 		SemConv(name, namespace, instanceID)...,
 	))
 }
@@ -147,5 +146,5 @@ func WithResource(res *resource.Resource) Option {
 // WithAttributes initializes a serviceNameResource with attributes.
 // This is a deprecated function provided for convenence.
 func WithAttributes(attributes ...attribute.KeyValue) Option {
-	return WithResource(resource.NewWithAttributes(semconv.SchemaURL, attributes...))
+	return WithResource(resource.NewSchemaless(attributes...))
 }

--- a/go-kit/metrics/provider/otel/resource.go
+++ b/go-kit/metrics/provider/otel/resource.go
@@ -128,6 +128,12 @@ func WithEnvironmentStandard(env string) Option {
 // duplicate attributes will be overwritten.
 func WithResource(res *resource.Resource) Option {
 	return func(cfg *config) error {
+		// If no base resource exists yet, use the provided resource directly
+		if cfg.serviceResource == nil {
+			cfg.serviceResource = res
+			return nil
+		}
+
 		merged, err := resource.Merge(cfg.serviceResource, res)
 		if err != nil {
 			return fmt.Errorf("failed to merge resources: %w", err)


### PR DESCRIPTION
Eliminates schema URL version conflicts by using schemaless resources throughout the provider initialization, then applying a schema at the end only if the user hasn't provided one.

## Problem

Applications upgrading their OpenTelemetry SDK encounter schema URL conflicts:
```
failed to merge resources: conflicting Schema URL: 
https://opentelemetry.io/schemas/1.39.0 and https://opentelemetry.io/schemas/1.37.0
```

This occurs when downstream applications use a different OTel SDK version than this library.

## Solution

Uses schemaless resources to avoid conflicts during merging:

1. Start with schemaless base (environment detection without schema)
2. All helper functions create schemaless resources
3. All merging happens without schemas (no conflicts possible)
4. At the end, apply library's schema only if user didn't provide one

**Changes:**
- All resource helpers now use `resource.NewSchemaless()`
- Provider starts with schemaless base from `resource.Default()`
- Final check adds library's schema (v1.37.0) if missing

## Backward Compatibility

Existing code works unchanged - uses library's v1.37.0 schema by default.

## Upgrade Path

Users with newer OTel SDK versions can provide their own schema:
```go
import semconv "go.opentelemetry.io/otel/semconv/v1.39.0"

base := resource.NewWithAttributes(semconv.SchemaURL)
p, err := otel.New(ctx, "my-service",
    otel.WithResource(base),
    otel.WithOpenTelemetryStandardService("my-service", "my-ns", "inst-1"),
)
```

All helpers merge schemaless attributes while preserving the user's schema version.