### PR TITLE
Apply schema URL conflict fixes to cmdutil-v2

### DIFF
--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+
 	xmetrics "github.com/heroku/x/go-kit/metrics"
 )
 
@@ -78,10 +80,14 @@ type exporterFactory func(*config) (metric.Exporter, error)
 // New returns a new, unstarted Provider. Use its Start() method to start
 // and establish a connection with its exporter's collector agent.
 func New(ctx context.Context, serviceName string, opts ...Option) (xmetrics.Provider, error) {
+	// Start with environment detection but strip the schema to avoid conflicts
+	base := resource.Default()
+	schemalessBase := resource.NewSchemaless(base.Attributes()...)
+
 	cfg := &config{
 		ctx:             ctx,
 		collectPeriod:   DefaultReaderInterval,
-		serviceResource: nil,
+		serviceResource: schemalessBase,
 	}
 	defaultOpts := []Option{
 		WithServiceStandard(serviceName),
@@ -96,9 +102,12 @@ func New(ctx context.Context, serviceName string, opts ...Option) (xmetrics.Prov
 		}
 	}
 
-	// If no resource was provided, use the default
-	if cfg.serviceResource == nil {
-		cfg.serviceResource = resource.Default()
+	// If no schema was provided by user, add library's default schema
+	if cfg.serviceResource.SchemaURL() == "" {
+		cfg.serviceResource = resource.NewWithAttributes(
+			semconv.SchemaURL,
+			cfg.serviceResource.Attributes()...,
+		)
 	}
 
 	p := Provider{

--- a/go-kit/metrics/provider/otel/provider.go
+++ b/go-kit/metrics/provider/otel/provider.go
@@ -81,7 +81,7 @@ func New(ctx context.Context, serviceName string, opts ...Option) (xmetrics.Prov
 	cfg := &config{
 		ctx:             ctx,
 		collectPeriod:   DefaultReaderInterval,
-		serviceResource: resource.Default(), // this fetches from env by default and pre-populates some fields.
+		serviceResource: nil,
 	}
 	defaultOpts := []Option{
 		WithServiceStandard(serviceName),
@@ -94,6 +94,11 @@ func New(ctx context.Context, serviceName string, opts ...Option) (xmetrics.Prov
 		if err := opt(cfg); err != nil {
 			return nil, fmt.Errorf("failed to apply options: %w", err)
 		}
+	}
+
+	// If no resource was provided, use the default
+	if cfg.serviceResource == nil {
+		cfg.serviceResource = resource.Default()
 	}
 
 	p := Provider{

--- a/go-kit/metrics/provider/otel/resource.go
+++ b/go-kit/metrics/provider/otel/resource.go
@@ -127,12 +127,6 @@ func WithEnvironmentStandard(env string) Option {
 // duplicate attributes will be overwritten.
 func WithResource(res *resource.Resource) Option {
 	return func(cfg *config) error {
-		// If no base resource exists yet, use the provided resource directly
-		if cfg.serviceResource == nil {
-			cfg.serviceResource = res
-			return nil
-		}
-
 		merged, err := resource.Merge(cfg.serviceResource, res)
 		if err != nil {
 			return fmt.Errorf("failed to merge resources: %w", err)

--- a/go-kit/metrics/provider/otel/resource.go
+++ b/go-kit/metrics/provider/otel/resource.go
@@ -104,8 +104,7 @@ func EnvironmentConv(stage string) []attribute.KeyValue {
 // WithOpenTelemetryStandardService returns an Option that configures service
 // attributes according to open-telemetry semconv conventions.
 func WithOpenTelemetryStandardService(name, namespace, instanceID string) Option {
-	return WithResource(resource.NewWithAttributes(
-		semconv.SchemaURL,
+	return WithResource(resource.NewSchemaless(
 		SemConv(name, namespace, instanceID)...,
 	))
 }
@@ -147,5 +146,5 @@ func WithResource(res *resource.Resource) Option {
 // WithAttributes initializes a serviceNameResource with attributes.
 // This is a deprecated function provided for convenence.
 func WithAttributes(attributes ...attribute.KeyValue) Option {
-	return WithResource(resource.NewWithAttributes(semconv.SchemaURL, attributes...))
+	return WithResource(resource.NewSchemaless(attributes...))
 }

--- a/go-kit/metrics/provider/otel/resource.go
+++ b/go-kit/metrics/provider/otel/resource.go
@@ -128,6 +128,12 @@ func WithEnvironmentStandard(env string) Option {
 // duplicate attributes will be overwritten.
 func WithResource(res *resource.Resource) Option {
 	return func(cfg *config) error {
+		// If no base resource exists yet, use the provided resource directly
+		if cfg.serviceResource == nil {
+			cfg.serviceResource = res
+			return nil
+		}
+
 		merged, err := resource.Merge(cfg.serviceResource, res)
 		if err != nil {
 			return fmt.Errorf("failed to merge resources: %w", err)


### PR DESCRIPTION
## Summary

Cherry-picks the schema URL conflict fixes from #280 onto the `cmdutil-v2` branch.

- Allow custom base resource in otel provider to prevent schema URL conflicts
- Make all resource helpers schemaless to prevent conflicts
- Use schemaless base with final schema application to prevent conflicts

## Test plan

- [ ] Verify otel provider resource helpers behave correctly in v2 context
- [ ] Confirm no schema URL conflicts when composing multiple resources