### PR TITLE
fix(cmdutil/debug): serve /debug/pprof/profile (CPU) and friends

### DIFF
--- a/cmdutil/debug/debug.go
+++ b/cmdutil/debug/debug.go
@@ -154,9 +154,22 @@ func NewPProfServer(l logrus.FieldLogger, pprofConfig *PProf) *PProfServer {
 		runtime.SetBlockProfileRate(pprofConfig.BlockProfileRate)
 	}
 
+	// Register every stdlib pprof handler on a private mux. Using only
+	// http.HandlerFunc(pprof.Index) serves the snapshot profiles (heap,
+	// goroutine, mutex, block, allocs, threadcreate) but returns 404 for
+	// /debug/pprof/{profile,trace,cmdline,symbol} because those are
+	// separate handlers in net/http/pprof — Index only dispatches to
+	// pprof.Lookup. Wiring them explicitly makes CPU profiling work.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
 	httpServer := &http.Server{
 		Addr:              fmt.Sprintf("127.0.0.1:%d", pprofConfig.Port),
-		Handler:           http.HandlerFunc(pprof.Index),
+		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/cmdutil/debug/debug_test.go
+++ b/cmdutil/debug/debug_test.go
@@ -85,6 +85,28 @@ func TestNewPProfServer(t *testing.T) {
 				resp.Body.Close()
 			})
 
+			// /debug/pprof/{profile,cmdline,symbol,trace} are handled by
+			// separate funcs in net/http/pprof — Index alone returns 404
+			// for them. Verify each is wired so CPU profiling works.
+			extraPaths := []string{
+				"/debug/pprof/profile?seconds=1",
+				"/debug/pprof/cmdline",
+				"/debug/pprof/symbol",
+			}
+			for _, p := range extraPaths {
+				extURL := "http://" + server.addr + p
+				t.Run("GET "+extURL, func(t *testing.T) {
+					resp, err := client.Get(extURL)
+					if err != nil {
+						t.Fatalf("client.Get(%s) error = %v", extURL, err)
+					}
+					defer resp.Body.Close()
+					if resp.StatusCode != http.StatusOK {
+						t.Errorf("status = %v, want %v", resp.StatusCode, http.StatusOK)
+					}
+				})
+			}
+
 			// Stop the server
 			server.Stop(nil)
 


### PR DESCRIPTION
## Summary

`NewPProfServer` installs `http.HandlerFunc(pprof.Index)` as the only HTTP handler on the debug port. That dispatches fine for the **snapshot** profiles — `/debug/pprof/{heap,goroutine,mutex,block,allocs,threadcreate}` — because `Index` resolves those via `pprof.Lookup`. But `/debug/pprof/profile` (CPU), `/trace`, `/cmdline`, and `/symbol` are **separate handlers** in `net/http/pprof`. Index does not route to them, so every request to those paths currently returns:

```
HTTP 404 Not Found: Unknown profile
```

CPU profiling is the most common thing people actually want from pprof in production, and it's been silently broken on every service that uses this package.

## Fix

Build a private `ServeMux` and register each stdlib pprof handler on it, mirroring what `net/http/pprof.init()` does against the global mux:

```go
mux := http.NewServeMux()
mux.HandleFunc("/debug/pprof/", pprof.Index)
mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
```

Private mux (not `DefaultServeMux`) preserves the existing isolation — no risk of pprof routes colliding with anything another package registered globally.


## Test plan

- [x] `go test ./cmdutil/debug/` passes
- [x] Extended `TestNewPProfServer` to `GET /debug/pprof/profile?seconds=1`, `/cmdline`, `/symbol` and assert each returns 200
- [x] Verified the new subtests fail with 404 when the handler change is reverted (so they actually exercise the fix, not just Index)
- [ ] Downstream smoke: re-run `runtime-fir-performance-testing` router-profiling manifest after this is vendored into fir-ingress; expect `merged-cpu.pb.gz` to appear alongside the other fleet profiles